### PR TITLE
feat: Better Auth

### DIFF
--- a/plugins/initial-auth.js
+++ b/plugins/initial-auth.js
@@ -1,5 +1,11 @@
 import { authService } from '@/services'
 
 export default async (context) => {
-  await authService.rememberUser(context)
+  await authService.silentRefresh(context)
+  window.addEventListener('storage', (event) => {
+    if (event.key === 'logout' && authService.isLoggedIn(context)) {
+      authService.logout(context, false)
+      if (context.route.path !== '/') context.redirect('/')
+    }
+  })
 }

--- a/plugins/vue-apollo.config.js
+++ b/plugins/vue-apollo.config.js
@@ -1,5 +1,6 @@
 import { createApolloClient } from 'vue-cli-plugin-apollo/graphql-client'
 import VueApollo from 'vue-apollo'
+import authService from '@/services/authService'
 
 // Config
 const defaultOptions = {
@@ -21,6 +22,10 @@ export default (context) => {
     ...defaultOptions,
     httpEndpoint: context.$config.api.graphql_endpoint,
     authenticationType: 'JWT',
+    getAuth: () => {
+      if (authService.currentAuthToken(context))
+        return `JWT ${authService.currentAuthToken(context)}`
+    },
   }
 }
 

--- a/store/auth.js
+++ b/store/auth.js
@@ -2,12 +2,16 @@ import { authService } from '@/services'
 import gql from 'graphql-tag'
 
 export const state = () => ({
+  token: null,
   user: null,
 })
 
 export const mutations = {
   SET_AUTH_USER(state, userDetails) {
     state.user = userDetails
+  },
+  SET_TOKEN(state, token) {
+    state.token = token
   },
 }
 
@@ -30,5 +34,12 @@ export const actions = {
     if (!userInfo) return authService.logout(nuxtContext)
 
     context.commit('SET_AUTH_USER', userInfo)
+  },
+  login(context, token) {
+    context.commit('SET_TOKEN', token)
+  },
+  logout(context) {
+    context.commit('SET_AUTH_USER', null)
+    context.commit('SET_TOKEN', null)
   },
 }

--- a/tests/unit/components/AuthBox.spec.js
+++ b/tests/unit/components/AuthBox.spec.js
@@ -127,7 +127,7 @@ describe('AuthBox', function () {
     })
 
     it('redirects to intended on successful login if has', async () => {
-      let fakePush, onLoginFn, storeDispatchFn
+      let fakePush, storeDispatchFn
 
       authBoxComponent = await mountWithRouterMock(
         UserAuthBox,
@@ -137,9 +137,6 @@ describe('AuthBox', function () {
               query: {
                 redirect: '/some/path',
               },
-            },
-            $apolloHelpers: {
-              onLogin: (onLoginFn = jest.fn()),
             },
             $store: {
               dispatch: (storeDispatchFn = jest.fn()),
@@ -170,14 +167,13 @@ describe('AuthBox', function () {
 
       await authBoxComponent.vm.attemptLogin()
       expect(fakePush.mock.calls[0][0]).to.eq('/some/path')
-      expect(onLoginFn.mock.calls).length(1)
-      expect(onLoginFn.mock.calls[0][0]).to.eq(
+      expect(storeDispatchFn.mock.calls).length(2)
+      expect(storeDispatchFn.mock.calls[0][0]).to.eq('auth/login')
+      expect(storeDispatchFn.mock.calls[0][1]).to.eq(
         '36c86c19f8f8d73aa59c3a00814137bdee0ab8de'
       )
-      expect(onLoginFn.mock.calls[0][2].expires).to.eq(null)
-      expect(storeDispatchFn.mock.calls).length(1)
-      expect(storeDispatchFn.mock.calls[0][0]).to.eq('auth/loadUserDetails')
-      expect(storeDispatchFn.mock.calls[0][1].userInfo.email).to.eq(
+      expect(storeDispatchFn.mock.calls[1][0]).to.eq('auth/loadUserDetails')
+      expect(storeDispatchFn.mock.calls[1][1].userInfo.email).to.eq(
         'm.pegg@example.org'
       )
     })


### PR DESCRIPTION
- Stops storing the JWTs in cookies (these can be scalped by attackers in XSS or CSRF attacks). Now stored in memory
- Implements cross-tab logout syncing