### PR TITLE
Feat/performance description

### DIFF
--- a/components/admin/AdminSidebar.vue
+++ b/components/admin/AdminSidebar.vue
@@ -1,18 +1,18 @@
 <template>
-  <sidebar class="flex-none" @close="$emit('close')"
-    ><sidebar-item icon="home" href="/administration" :is-root="true"
-      >Dashboard</sidebar-item
-    >
+  <sidebar class="flex-none" @close="$emit('close')">
+    <sidebar-item icon="home" href="/administration" :is-root="true">
+      Dashboard
+    </sidebar-item>
     <!-- <sidebar-item icon="users" href="/administration/users">Users</sidebar-item>
     <sidebar-item icon="people-arrows" href="/administration/societies"
       >Societies</sidebar-item
     > -->
-    <sidebar-item icon="theater-masks" href="/administration/productions"
-      >Productions</sidebar-item
-    >
-    <sidebar-item icon="money-bill" href="/administration/finance-reports"
-      >Finance Reports</sidebar-item
-    >
+    <sidebar-item icon="theater-masks" href="/administration/productions">
+      Productions
+    </sidebar-item>
+    <sidebar-item icon="money-bill" href="/administration/finance-reports">
+      Finance Reports
+    </sidebar-item>
   </sidebar>
 </template>
 

--- a/components/admin/permissions/PermissionsAssigner.vue
+++ b/components/admin/permissions/PermissionsAssigner.vue
@@ -23,8 +23,8 @@
           class="text-center"
         >
           <table-row-item>
-            {{ assignedUser.user.firstName }} {{ assignedUser.user.lastName
-            }}<br />
+            {{ assignedUser.user.firstName }} {{ assignedUser.user.lastName }}
+            <br />
             <sta-button
               :small="true"
               class="
@@ -34,8 +34,9 @@
                 mt-2
               "
               @click="removeUser(assignedUser)"
-              >Remove</sta-button
             >
+              Remove
+            </sta-button>
           </table-row-item>
           <table-row-item
             v-for="(permission, apIndex) in assignablePermissions"
@@ -95,8 +96,9 @@
         class="bg-sta-green hover:bg-sta-green-dark transition-colors"
         :disabled="!newUser.email"
         @click="addNewUser"
-        >Add New</sta-button
       >
+        Add New
+      </sta-button>
     </div>
   </div>
 </template>

--- a/components/performance/TimeGroupedPerformanceSelector.vue
+++ b/components/performance/TimeGroupedPerformanceSelector.vue
@@ -9,7 +9,9 @@
       <h2 class="mb-2 text-white text-2xl font-semibold">
         {{ time }}
       </h2>
-      <div class="grid gap-2 grid-cols-2 md:gap-4 md:grid-cols-4">
+      <div
+        class="grid gap-2 grid-cols-2 lg:gap-4 lg:grid-cols-3 xl:grid-cols-4"
+      >
         <performance-overview
           v-for="(performance, index) in performanceGroup"
           :key="index"

--- a/components/performance/TimeGroupedPerformanceSelector.vue
+++ b/components/performance/TimeGroupedPerformanceSelector.vue
@@ -9,9 +9,7 @@
       <h2 class="mb-2 text-white text-2xl font-semibold">
         {{ time }}
       </h2>
-      <div
-        class="grid gap-2 grid-cols-2 lg:gap-4 lg:grid-cols-3 xl:grid-cols-4"
-      >
+      <div class="grid gap-2 grid-cols-2 lg:gap-4 xl:grid-cols-3">
         <performance-overview
           v-for="(performance, index) in performanceGroup"
           :key="index"

--- a/components/performance/editor/PerformanceEditor.vue
+++ b/components/performance/editor/PerformanceEditor.vue
@@ -123,16 +123,20 @@
                 :removable="true"
                 @remove="performanceSeatGroups.splice(index, 1)"
               />
+              <alert v-if="!venue" class="text-sm" level="warning">
+                You must select a venue before adding seat groups
+              </alert>
               <alert
                 v-if="
                   venue && selectedSeatGroupCapacities > venue.internalCapacity
                 "
                 class="text-sm"
                 level="warning"
-                ><strong>NB:</strong> Venue capacity will limit this
-                performance's capacity automatically to
-                {{ venue.internalCapacity }}</alert
               >
+                <strong>NB:</strong> Venue capacity will limit this
+                performance's capacity automatically to
+                {{ venue.internalCapacity }}
+              </alert>
             </div>
           </div>
           <div class="px-2 border border-sta-gray rounded-lg">
@@ -152,7 +156,8 @@
                 :removable="true"
                 :editable="true"
                 @remove="deleteConcession(discount)"
-                ><template
+              >
+                <template
                   v-if="discount.performances.edges.length > 1"
                   #editor-footer
                 >
@@ -161,8 +166,8 @@
                     {{ discount.performances.edges.length - 1 }} other
                     performances.
                   </alert>
-                </template></concession-type
-              >
+                </template>
+              </concession-type>
             </div>
           </div>
         </div>
@@ -205,10 +210,10 @@
               @change="$emit('update:disabled', $event)"
             />
           </template>
-          <template #helper
-            >Disabled performances will not show, and will not be available for
-            booking</template
-          >
+          <template #helper>
+            Disabled performances will not show, and will not be available for
+            booking
+          </template>
         </form-label>
         <form-label name="capacity" :errors="errors">
           Performance Capacity
@@ -223,8 +228,8 @@
               "
             />
           </template>
-          <template #helper
-            >Optionally, add the capacity of the performance. If not given, the
+          <template #helper>
+            Optionally, add the capacity of the performance. If not given, the
             capacity from the seat groups assigned will be used. You can reserve
             comp seats later - this should be representitive of the total number
             of seats actually phsyically allowed.

--- a/components/performance/editor/PriceMatrix.vue
+++ b/components/performance/editor/PriceMatrix.vue
@@ -30,10 +30,11 @@
             <badge
               v-if="discount.performances.edges.length > 1"
               class="bg-blue-400"
-              ><font-awesome-icon icon="sync"
-            /></badge>
-            <template #control
-              ><percentage-input
+            >
+              <font-awesome-icon icon="sync" />
+            </badge>
+            <template #control>
+              <percentage-input
                 v-if="editing"
                 :key="discount.id"
                 :value="discount.percentage * 100"
@@ -46,8 +47,8 @@
               />
               <div v-else class="font-bold">
                 {{ discount.percentage * 100 }}%
-              </div></template
-            >
+              </div>
+            </template>
           </form-label>
         </th>
       </tr>
@@ -77,8 +78,8 @@
               </div>
               <div v-else class="font-bold">
                 £{{ performanceSeatGroup.price / 100 }}
-              </div></template
-            >
+              </div>
+            </template>
           </form-label>
         </th>
         <td v-for="discount in singleDiscounts" :key="discount.id">

--- a/components/performance/editor/SeatGroup.vue
+++ b/components/performance/editor/SeatGroup.vue
@@ -1,15 +1,18 @@
 <template>
   <div class="flex items-center p-3 bg-sta-gray-dark rounded-lg">
     <p class="font-semibold">
-      {{ value.name }}<br /><small
-        >Max Capacity:
+      {{ value.name }}
+      <br />
+      <small>
+        Max Capacity:
         {{ capacityOverride ? capacityOverride : value.capacity }}
         <strike
           v-if="capacityOverride && capacityOverride !== value.capacity"
           class="text-sta-gray-lighter"
-          >{{ value.capacity }}</strike
-        ></small
-      >
+        >
+          {{ value.capacity }}
+        </strike>
+      </small>
     </p>
     <font-awesome-icon
       v-if="removable"

--- a/components/production/ProductionBanner.vue
+++ b/components/production/ProductionBanner.vue
@@ -80,7 +80,7 @@
             £{{ (production.minSeatPrice / 100).toFixed(2) }}
           </span>
           <br />
-          <small>(excluding concessions)</small>
+          <small>(excluding concessions and fees)</small>
         </icon-list-item>
       </template>
       <button

--- a/components/production/ProductionBanner.vue
+++ b/components/production/ProductionBanner.vue
@@ -79,7 +79,8 @@
           <span class="font-semibold">
             £{{ (production.minSeatPrice / 100).toFixed(2) }}
           </span>
-          <br /><small>(excluding concessions)</small>
+          <br />
+          <small>(excluding concessions)</small>
         </icon-list-item>
       </template>
       <button

--- a/components/production/ProductionPerformances.vue
+++ b/components/production/ProductionPerformances.vue
@@ -17,7 +17,7 @@
       >
         No Upcoming Performances
       </div>
-      <div v-else class="flex flex-wrap justify-center lg:flex-nowrap">
+      <div v-else class="flex flex-wrap justify-center">
         <div
           v-for="performance in production.performances.edges.map(
             (edge) => edge.node

--- a/graphql/fragments/production/ProductionPerformancesFragment.gql
+++ b/graphql/fragments/production/ProductionPerformancesFragment.gql
@@ -9,6 +9,7 @@ fragment ProductionPerformances on ProductionNode {
           slug
         }
         disabled
+        description
         doorsOpen
         start
         end

--- a/pages/administration/index.vue
+++ b/pages/administration/index.vue
@@ -29,17 +29,15 @@
     <div>
       <h3 class="text-h3">Quick Links</h3>
       <div class="flex flex-wrap gap-3">
-        <nuxt-link to="/administration/productions"
-          ><div class="p-2 bg-sta-green">Your Live Productions</div></nuxt-link
-        >
-        <nuxt-link to="/administration/tools/ticket-lookup"
-          ><div class="p-2 bg-sta-green">
-            Ticket & Booking Lookup
-          </div></nuxt-link
-        >
-        <nuxt-link to="/administration/finance-reports"
-          ><div class="p-2 bg-sta-green">Finance Reporting</div></nuxt-link
-        >
+        <nuxt-link to="/administration/productions">
+          <div class="p-2 bg-sta-green">Your Live Productions</div>
+        </nuxt-link>
+        <nuxt-link to="/administration/tools/ticket-lookup">
+          <div class="p-2 bg-sta-green">Ticket & Booking Lookup</div>
+        </nuxt-link>
+        <nuxt-link to="/administration/finance-reports">
+          <div class="p-2 bg-sta-green">Finance Reporting</div>
+        </nuxt-link>
       </div>
     </div>
   </div>

--- a/pages/production/_slug/book.vue
+++ b/pages/production/_slug/book.vue
@@ -31,11 +31,12 @@
             class="p-2 bg-sta-green-dark my-2 rounded text-center shadow-inner"
           >
             You have
-            <strong
-              ><time-remaining-countdown
+            <strong>
+              <time-remaining-countdown
                 :expires-at="booking.raw.expiresAt"
                 @finished="bookingExpired"
-            /></strong>
+              />
+            </strong>
             to complete this booking
           </div>
         </div>

--- a/pages/production/_slug/book/_performanceId/warnings.vue
+++ b/pages/production/_slug/book/_performanceId/warnings.vue
@@ -1,8 +1,12 @@
 <template>
   <div class="flex flex-col items-center justify-evenly min-h-full">
-    <card v-if="booking.performance.description" class="w-full mb-2">
+    <card
+      v-if="booking.performance.description"
+      ref="perf-description"
+      class="w-full mb-2"
+    >
       <template #subtitle>
-        <span class="text-xl"> Performance Information</span>
+        <span class="text-xl">Performance Information</span>
       </template>
       {{ booking.performance.description }}
     </card>

--- a/pages/production/_slug/book/_performanceId/warnings.vue
+++ b/pages/production/_slug/book/_performanceId/warnings.vue
@@ -1,5 +1,11 @@
 <template>
   <div class="flex flex-col items-center justify-evenly min-h-full">
+    <card v-if="booking.performance.description" class="w-full mb-2">
+      <template #subtitle>
+        <span class="text-xl"> Performance Information</span>
+      </template>
+      {{ booking.performance.description }}
+    </card>
     <div class="mb-2 p-6 pt-3 text-white bg-sta-rouge">
       <h2 class="text-h3 sm:text-h2">
         Please note the following warnings for this production:
@@ -25,16 +31,27 @@
 
 <script>
 import BookingStage from '@/classes/BookingStage'
+import Booking from '@/classes/Booking'
+import Card from '@/components/ui/Card.vue'
+
 export default {
   stageInfo: new BookingStage({
     name: 'Auidence Warnings',
     routeName: 'production-slug-book-performanceId-warnings',
-    shouldBeUsed: (production) => production.warnings.length > 0,
+    shouldBeUsed: (production, booking) =>
+      production.warnings.length > 0 || booking.performance.description,
   }),
+  components: {
+    Card,
+  },
   props: {
     production: {
       required: true,
       type: Object,
+    },
+    booking: {
+      required: true,
+      type: Booking,
     },
   },
   methods: {

--- a/tests/unit/pages/booking/BookingStages.spec.js
+++ b/tests/unit/pages/booking/BookingStages.spec.js
@@ -26,15 +26,77 @@ describe('Booking Stages', () => {
     expect(
       getStageIndex(getNextStage(null, { warnings: ['strobe lighting'] }))
     ).to.eq(1)
-    // with warnings
+
+    // with warnings and no perf_description
     expect(
-      getStageIndex(getNextStage(0, { warnings: ['strobe lighting'] }))
+      getStageIndex(
+        getNextStage(
+          0,
+          { warnings: ['strobe lighting'] },
+          { performance: { description: 'perf_description' } }
+        )
+      )
     ).to.eq(1)
     expect(
-      getStageIndex(getNextStage(1, { warnings: ['strobe lighting'] }))
+      getStageIndex(
+        getNextStage(
+          1,
+          { warnings: ['strobe lighting'] },
+          { performance: { description: 'perf_description' } }
+        )
+      )
     ).to.eq(2)
-    // no warnings
-    expect(getStageIndex(getNextStage(0, { warnings: [] }))).to.eq(2)
+
+    // with warnings and perf_description
+    expect(
+      getStageIndex(
+        getNextStage(
+          0,
+          { warnings: ['strobe lighting'] },
+          { performance: { description: 'perf_description' } }
+        )
+      )
+    ).to.eq(1)
+    expect(
+      getStageIndex(
+        getNextStage(
+          1,
+          { warnings: ['strobe lighting'] },
+          { performance: { description: 'perf_description' } }
+        )
+      )
+    ).to.eq(2)
+
+    // perf description, and no warnings
+    expect(
+      getStageIndex(
+        getNextStage(
+          0,
+          { warnings: [] },
+          { performance: { description: 'perf_description' } }
+        )
+      )
+    ).to.eq(1)
+    expect(
+      getStageIndex(
+        getNextStage(
+          1,
+          { warnings: [] },
+          { performance: { description: 'perf_description' } }
+        )
+      )
+    ).to.eq(2)
+
+    // no warnings and no perf description
+    expect(
+      getStageIndex(
+        getNextStage(
+          0,
+          { warnings: [] },
+          { performance: { description: null } }
+        )
+      )
+    ).to.eq(2)
 
     expect(getStageIndex(getNextStage(2, {}))).to.eq(3)
     expect(getStageIndex(getNextStage(3, {}))).to.eq(4)
@@ -43,12 +105,40 @@ describe('Booking Stages', () => {
   it('can get the previous stage', () => {
     expect(
       getStageIndex(
-        getPreviousStage(stages[1], { warnings: ['strobe lighting'] }, {})
+        getPreviousStage(
+          stages[1],
+          { warnings: ['strobe lighting'] },
+          { performance: { description: 'perf_description' } }
+        )
       )
     ).to.eq(0)
     expect(
-      getStageIndex(getPreviousStage(1, { warnings: ['strobe lighting'] }, {}))
+      getStageIndex(
+        getPreviousStage(
+          1,
+          { warnings: ['strobe lighting'] },
+          { performance: { description: 'perf_description' } }
+        )
+      )
     ).to.eq(0)
-    expect(getStageIndex(getPreviousStage(2, { warnings: [] }, {}))).to.eq(0)
+
+    expect(
+      getStageIndex(
+        getPreviousStage(
+          2,
+          { warnings: [] },
+          { performance: { description: null } }
+        )
+      )
+    ).to.eq(0)
+    expect(
+      getStageIndex(
+        getPreviousStage(
+          2,
+          { warnings: [] },
+          { performance: { description: 'perf_description' } }
+        )
+      )
+    ).to.eq(1)
   })
 })

--- a/tests/unit/pages/booking/stages/AudienceWarningsStage.spec.js
+++ b/tests/unit/pages/booking/stages/AudienceWarningsStage.spec.js
@@ -3,25 +3,62 @@ import { expect } from 'chai'
 
 import AudienceWarningsStage from '@/pages/production/_slug/book/_performanceId/warnings.vue'
 import Production from '@/tests/unit/fixtures/Production'
+import Booking from '@/tests/unit/fixtures/Booking'
 
 describe('Audience Warnings Stage', () => {
-  let stageComponent
+  let warningComponent
 
-  beforeAll(() => {
-    stageComponent = mount(AudienceWarningsStage, {
-      propsData: {
-        production: Production(),
-      },
+  describe('with warnings, and no performance description', () => {
+    beforeAll(() => {
+      warningComponent = mount(AudienceWarningsStage, {
+        propsData: {
+          production: Production(),
+          booking: Booking({ performance: { descrption: null } }),
+        },
+      })
+    })
+
+    it('doesnt display any production description', () => {
+      expect(warningComponent.text()).to.not.contain('Performance Information')
+      expect(warningComponent.text()).to.not.contain(
+        'the performance description'
+      )
+    })
+
+    it('displays the warnings', () => {
+      expect(warningComponent.text()).to.contain('Strobe Lighting')
+      expect(warningComponent.text()).to.contain('Nudity')
+    })
+
+    it('emits event on understood', () => {
+      warningComponent.find('button').trigger('click')
+      expect(warningComponent.emitted('next-stage').length).to.eq(1)
     })
   })
 
-  it('displays the warnings', () => {
-    expect(stageComponent.text()).to.contain('Strobe Lighting')
-    expect(stageComponent.text()).to.contain('Nudity')
-  })
+  describe('with performance description and no warnings', () => {
+    beforeAll(() => {
+      warningComponent = mount(AudienceWarningsStage, {
+        propsData: {
+          production: Production({ warnings: [] }),
+          booking: Booking(),
+        },
+      })
+    })
 
-  it('emits event on understood', () => {
-    stageComponent.find('button').trigger('click')
-    expect(stageComponent.emitted('next-stage').length).to.eq(1)
+    it('displays the production description', () => {
+      expect(warningComponent.text()).to.contain('Performance Information')
+      expect(warningComponent.text()).to.contain('the performance description')
+    })
+
+    it('doesnt display any warnings', () => {
+      expect(warningComponent.text()).to.not.contain('Strobe Lighting')
+      expect(warningComponent.text()).to.not.contain('Nudity')
+    })
+
+    it('emits event on understood', () => {
+      warningComponent.find('button').trigger('click')
+      expect(warningComponent.emitted('next-stage').length).to.eq(1)
+    })
   })
 })


### PR DESCRIPTION
Adds performacne description to warnings stage. 

Additionaly does soem small linting on the admin panel and adds a notification when selecting seatgroups with no venue selected.

closes #218 