### PR TITLE
fix/ Make 'What's On' spelling uniform and correct

### DIFF
--- a/components/layout/LayoutNavBar.vue
+++ b/components/layout/LayoutNavBar.vue
@@ -126,7 +126,7 @@ const userDropdownComponent = ref(null);
 const authStore = useAuthStore();
 const appConfig = useAppConfig();
 const navItems = [
-  [{ path: '/productions' }, 'Whats On'],
+  [{ path: '/productions' }, 'What\'s On'],
   [{ path: '/societies' }, 'Societies']
 ];
 const open = ref(false);

--- a/pages/production/[slug]/book.vue
+++ b/pages/production/[slug]/book.vue
@@ -193,7 +193,7 @@ export default defineNuxtComponent({
   },
   mounted() {
     this.breadcrumbs = [
-      { text: 'Whats On', path: '/productions' },
+      { text: 'What\'s On', path: '/productions' },
       {
         text: this.production.name,
         path: `/production/${this.production.slug}`

--- a/pages/production/[slug]/index.vue
+++ b/pages/production/[slug]/index.vue
@@ -137,7 +137,7 @@ export default defineNuxtComponent({
   },
   mounted() {
     this.breadcrumbs = [
-      { text: 'Whats On', path: '/productions' },
+      { text: 'What\'s On', path: '/productions' },
       { text: this.production?.name }
     ];
   }

--- a/pages/productions.vue
+++ b/pages/productions.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container">
-    <h1 class="py-4 text-h1">Whats On</h1>
+    <h1 class="py-4 text-h1">What's On</h1>
     <infinite-scroll
       :apollo-query="upcomingProductionsQuery"
       :apollo-variables="{ now: new Date() }"

--- a/tests/unit/components/ui/Breadcrumbs.spec.js
+++ b/tests/unit/components/ui/Breadcrumbs.spec.js
@@ -14,7 +14,7 @@ describe('Breadcrumbs', () => {
     breadcrumbsComponent = await mount(Breadcrumbs, {
       props: {
         crumbs: [
-          { text: 'Whats On', path: '/productions' },
+          { text: 'What\'s On', path: '/productions' },
           {
             text: 'Legally Ginger',
             path: '/productions/legally-ginger'
@@ -30,7 +30,7 @@ describe('Breadcrumbs', () => {
   });
 
   it('has corrct text', () => {
-    expect(breadcrumbsComponent.text()).to.contain('Whats On');
+    expect(breadcrumbsComponent.text()).to.contain('What's On');
     expect(breadcrumbsComponent.text()).to.contain('Legally Ginger');
     expect(breadcrumbsComponent.text()).to.contain('Book');
   });


### PR DESCRIPTION
There was both an inconsistency in spelling between `Whats On` and `What's On`, and more importantly the later is [just correct](https://dictionary.cambridge.org/dictionary/english/what-s-on). This is a PR to fix the issue and correct the spelling across the board.