### PR TITLE
feat: Fetch Booking Fees for Display

### DIFF
--- a/components/production/ProductionBanner.vue
+++ b/components/production/ProductionBanner.vue
@@ -196,8 +196,6 @@ export default {
         0
       );
 
-      console.log(totalPercentage, totalValue);
-
       // Returns the total percentage and value of all misc costs in format totalPercentage + totalValue, but hide each if the value is 0
       // If the total value is greater than 100 (i.e. £1), it is displayed in pounds, otherwise displayed in pence
       return `${totalPercentage ? `${totalPercentage}%` : ''}${

--- a/components/production/ProductionBanner.vue
+++ b/components/production/ProductionBanner.vue
@@ -64,8 +64,8 @@
           <template
             v-if="
               production.performances.edges
-                .map((edge: any) => edge.node)
-                .find((node: any) => node.intervalDurationMins)
+                .map((edge) => edge.node)
+                .find((node) => node.intervalDurationMins)
             "
           >
             <small>(inc. interval)</small>
@@ -77,9 +77,13 @@
             <span class="font-semibold">
               £{{ (production.minSeatPrice / 100).toFixed(2) }}
             </span>
-            <UTooltip class="pl-1" :popper="{ arrow: true }">
+            <UTooltip
+              v-if="miscCostsDisplay"
+              class="pl-1"
+              :popper="{ arrow: true }"
+            >
               <template #text>
-                <span>10% + £1 to cover fees and support student theatre.</span>
+                {{ miscCostsDisplay }} to cover fees and support our theatre.
               </template>
               <small
                 >(exc. fees)<font-awesome-icon icon="circle-info" class="ml-1"
@@ -92,8 +96,8 @@
       <button
         v-if="showBuyTicketsButton && production.isBookable"
         class="btn btn-green mt-4 w-full font-semibold"
-        @click="emit('on-buy-tickets-click')"
-        @keypress="emit('on-buy-tickets-click')"
+        @click="$emit('on-buy-tickets-click')"
+        @keypress="$emit('on-buy-tickets-click')"
       >
         Buy Tickets
       </button>
@@ -101,72 +105,112 @@
   </div>
 </template>
 
-<script setup lang="ts">
+<script>
 import humanizeDuration from 'humanize-duration';
 import lo from 'lodash';
 
 import ProductionFeaturedImage from './ProductionFeaturedImage.vue';
 import IconListItem from '~~/components/ui/UiIconListItem.vue';
 import { displayStartEnd } from '@/utils/datetime';
+import MiscCostQuery from '@/graphql/queries/MiscCosts.gql';
 
-const emit = defineEmits<{
-  (event: 'on-buy-tickets-click'): void;
-}>();
-
-const props = defineProps({
-  production: {
-    required: true,
-    type: Object
+export default {
+  components: {
+    ProductionFeaturedImage,
+    IconListItem
   },
-  showBuyTicketsButton: {
-    default: true,
-    type: Boolean
+  props: {
+    production: {
+      required: true,
+      type: Object
+    },
+    showBuyTicketsButton: {
+      default: true,
+      type: Boolean
+    },
+    showDetailedInfo: {
+      default: true,
+      type: Boolean
+    }
   },
-  showDetailedInfo: {
-    default: true,
-    type: Boolean
+  emits: ['on-buy-tickets-click'],
+  apollo: {
+    miscCosts: {
+      query: MiscCostQuery,
+      update: (data) => data.miscCosts.edges.map((edge) => edge.node)
+    }
+  },
+  data() {
+    return {
+      venueOverflow: 3,
+      miscCosts: []
+    };
+  },
+  computed: {
+    hasOnlinePerformances() {
+      return !!this.production.performances.edges.find(
+        (edge) => edge.node.isOnline
+      );
+    },
+    hasInPersonPerformances() {
+      return !!this.production.performances.edges.find(
+        (edge) => edge.node.isInperson
+      );
+    },
+    venues() {
+      let venueList = [];
+      if (this.hasInPersonPerformances) {
+        venueList = lo.uniqBy(
+          this.production.performances.edges.map((edge) => {
+            return edge.node.venue;
+          }),
+          'name'
+        );
+      }
+      lo.take(venueList, this.venueOverflow + 1);
+      return venueList;
+    },
+    duration() {
+      if (!this.production.performances.edges.length) {
+        return;
+      }
+      return humanizeDuration(
+        lo
+          .chain(this.production.performances.edges.map((edge) => edge.node))
+          .minBy('durationMins')
+          .value().durationMins *
+          60 *
+          1000
+      );
+    },
+    miscCostsDisplay() {
+      // The total percentage sum of all misc costs
+      const totalPercentage =
+        this.miscCosts
+          .reduce((acc, miscCost) => acc + miscCost.percentage, 0)
+          .toFixed(2) * 100;
+
+      // The total value sum of all misc costs in pence
+      const totalValue = this.miscCosts.reduce(
+        (acc, miscCost) => acc + miscCost.value,
+        0
+      );
+
+      console.log(totalPercentage, totalValue);
+
+      // Returns the total percentage and value of all misc costs in format totalPercentage + totalValue, but hide each if the value is 0
+      // If the total value is greater than 100 (i.e. £1), it is displayed in pounds, otherwise displayed in pence
+      return `${totalPercentage ? `${totalPercentage}%` : ''}${
+        totalValue
+          ? `${totalPercentage ? ' + ' : ''}${
+              totalValue >= 100 ? '£' + totalValue / 100 : totalValue + 'p'
+            }`
+          : ''
+      }`;
+    }
+  },
+  methods: {
+    displayStartEnd
   }
-});
-
-const venueOverflow = 3;
-
-const hasOnlinePerformances = computed(() => {
-  return !!props.production.performances.edges.find(
-    (edge: any) => edge.node.isOnline
-  );
-});
-
-const hasInPersonPerformances = computed(() => {
-  return !!props.production.performances.edges.find(
-    (edge: any) => edge.node.isInperson
-  );
-});
-
-const venues = computed(() => {
-  let venueList: any[] = [];
-  if (hasInPersonPerformances.value) {
-    venueList = lo.uniqBy(
-      props.production.performances.edges.map((edge: any) => {
-        return edge.node.venue;
-      }),
-      'name'
-    );
-  }
-  lo.take(venueList, venueOverflow + 1);
-  return venueList;
-});
-
-const duration = computed(() => {
-  if (!props.production.performances.edges.length) {
-    return;
-  }
-  return humanizeDuration(
-    lo
-      .chain(props.production.performances.edges.map((edge: any) => edge.node))
-      .minBy('durationMins')
-      .value().durationMins *
-      60 *
-      1000
-  );
-});
+};
 </script>

--- a/graphql/queries/MiscCosts.gql
+++ b/graphql/queries/MiscCosts.gql
@@ -2,7 +2,6 @@ query miscCosts {
   miscCosts {
     edges {
       node {
-        id
         name
         description
         percentage

--- a/graphql/queries/MiscCosts.gql
+++ b/graphql/queries/MiscCosts.gql
@@ -1,0 +1,13 @@
+query miscCosts {
+  miscCosts {
+    edges {
+      node {
+        id
+        name
+        description
+        percentage
+        value
+      }
+    }
+  }
+}

--- a/pages/administration/productions/[productionSlug]/edit.vue
+++ b/pages/administration/productions/[productionSlug]/edit.vue
@@ -54,7 +54,6 @@ export default defineNuxtComponent({
       this.errors = null;
       loadingSwal.fire();
       try {
-        console.log('Performing mutation');
         await performMutation(
           this.$apollo,
           {
@@ -65,8 +64,6 @@ export default defineNuxtComponent({
           },
           'production'
         );
-        console.log('Performed mutation');
-        console.log('Performing query');
         const { data } = await this.$apollo.query({
           query: AdminProductionEditQuery,
           variables: {
@@ -74,12 +71,7 @@ export default defineNuxtComponent({
           },
           fetchPolicy: 'no-cache'
         });
-        console.log('Performed query');
         this.production = data.production;
-        console.log(
-          'Rerouting to: ' +
-            `/administration/productions/${this.production.slug}`
-        );
         useRouter().navigateTo(
           `/administration/productions/${this.production.slug}`
         );

--- a/pages/administration/productions/[productionSlug]/edit.vue
+++ b/pages/administration/productions/[productionSlug]/edit.vue
@@ -54,6 +54,7 @@ export default defineNuxtComponent({
       this.errors = null;
       loadingSwal.fire();
       try {
+        console.log('Performing mutation');
         await performMutation(
           this.$apollo,
           {
@@ -64,14 +65,22 @@ export default defineNuxtComponent({
           },
           'production'
         );
+        console.log('Performed mutation');
+        console.log('Performing query');
         const { data } = await this.$apollo.query({
           query: AdminProductionEditQuery,
           variables: {
-            slug: this.production.slug
-          }
+            slug: await this.production.slug
+          },
+          fetchPolicy: 'no-cache'
         });
+        console.log('Performed query');
         this.production = data.production;
-        useRouter().replace(
+        console.log(
+          'Rerouting to: ' +
+            `/administration/productions/${this.production.slug}`
+        );
+        useRouter().navigateTo(
           `/administration/productions/${this.production.slug}`
         );
         successToast.fire({ title: 'Production Updated' });

--- a/pages/administration/productions/[productionSlug]/index.vue
+++ b/pages/administration/productions/[productionSlug]/index.vue
@@ -206,16 +206,17 @@ export default defineNuxtComponent({
   },
   async asyncData() {
     // Execute query
-    const { data } = await useAsyncQuery({
+    console.log('Fetching production');
+    const { data } = await useDefaultApolloClient().query({
       query: AdminProductionShowQuery,
       variables: {
         slug: useRoute().params.productionSlug
       },
       fetchPolicy: 'no-cache'
     });
-
-    const production = computed(() => data.value.production);
-    if (!production.value) {
+    const production = data.production;
+    console.log('Fetched production');
+    if (!production) {
       throw createSafeError({
         statusCode: 404,
         message: 'This production does not exist'
@@ -243,7 +244,7 @@ export default defineNuxtComponent({
         };
       },
       update: (data) => data.production.performances,
-      fetchPolicy: 'cache-and-network'
+      fetchPolicy: 'no-cache'
     }
   },
   computed: {

--- a/pages/administration/productions/[productionSlug]/index.vue
+++ b/pages/administration/productions/[productionSlug]/index.vue
@@ -206,16 +206,15 @@ export default defineNuxtComponent({
   },
   async asyncData() {
     // Execute query
-    console.log('Fetching production');
     const { data } = await useDefaultApolloClient().query({
       query: AdminProductionShowQuery,
       variables: {
         slug: useRoute().params.productionSlug
       },
-      fetchPolicy: 'no-cache'
+      fetchPolicy: 'no-cache',
+      server: false
     });
     const production = data.production;
-    console.log('Fetched production');
     if (!production) {
       throw createSafeError({
         statusCode: 404,
@@ -381,6 +380,16 @@ export default defineNuxtComponent({
           },
           'setProductionStatus'
         );
+
+        const { data } = await useDefaultApolloClient().query({
+          query: AdminProductionShowQuery,
+          variables: {
+            slug: useRoute().params.productionSlug
+          },
+          fetchPolicy: 'no-cache'
+        });
+
+        this.production = data.production;
       } catch (e) {
         const errors = getValidationErrors(e);
         swal.fire({
@@ -391,7 +400,7 @@ export default defineNuxtComponent({
         });
         return;
       }
-      await refreshNuxtData();
+
       successToast.fire({ title: 'Status updated' });
     }
   }

--- a/pages/administration/productions/[productionSlug]/performances/create.vue
+++ b/pages/administration/productions/[productionSlug]/performances/create.vue
@@ -4,7 +4,7 @@
       <UiStaButton colour="green" icon="save" @click="create">
         Create
       </UiStaButton>
-      <UiStaButton colour="orange" to="../../"> Cancel </UiStaButton>
+      <UiStaButton colour="orange" to="../"> Cancel </UiStaButton>
     </template>
     <UiNonFieldError :errors="errors" />
     <performance-editor

--- a/pages/administration/productions/[productionSlug]/permissions.vue
+++ b/pages/administration/productions/[productionSlug]/permissions.vue
@@ -144,7 +144,6 @@ export default defineNuxtComponent({
         fetchPolicy: 'no-cache'
       });
       this.production = data.production;
-      console.log(this.production);
 
       if (!this.production) {
         throw createSafeError({

--- a/tests/unit/components/production/ProductionBanner.spec.js
+++ b/tests/unit/components/production/ProductionBanner.spec.js
@@ -245,8 +245,108 @@ describe('ProductionBanner', function () {
     );
   });
 
+  describe('Production Fee Display', function () {
+    it('doesnt display fees if none exist', async () => {
+      await createWithPerformances([]);
+
+      expect(headerContainer.vm.miscCostsDisplay).to.equal('');
+      expect(headerContainer.text()).to.not.contain('(exc. fees)');
+    });
+
+    it('doesnt display if tickets are free', async () => {
+      await createWithPerformances(
+        [{}],
+        [
+          {
+            id: 1,
+            name: 'Booking Fee',
+            description: 'Supports theatre maintainance and website',
+            percentage: 0.05
+          }
+        ],
+        {
+          minSeatPrice: null
+        }
+      );
+
+      expect(headerContainer.text()).to.not.contain('(exc. fees)');
+    });
+
+    it('calculates correct fee with only a percentage', async () => {
+      await createWithPerformances(
+        [{}],
+        [
+          {
+            id: 1,
+            name: 'Booking Fee',
+            description: 'Supports theatre maintainance and website',
+            percentage: 0.05
+          }
+        ]
+      );
+
+      expect(headerContainer.vm.miscCostsDisplay).to.equal('5%');
+      expect(headerContainer.text()).to.contain('(exc. fees)');
+    });
+
+    it('calculates correct fee with only a fixed fee', async () => {
+      await createWithPerformances(
+        [{}],
+        [
+          {
+            id: 1,
+            name: 'Booking Fee',
+            description: 'Supports theatre maintainance and website',
+            value: 100
+          }
+        ]
+      );
+      console.log(headerContainer.vm.miscCosts);
+      console.log(headerContainer.html());
+
+      expect(headerContainer.vm.miscCostsDisplay).to.equal('£1');
+      expect(headerContainer.text()).to.contain('(exc. fees)');
+    });
+
+    it('calculates correct fee with', async () => {
+      await createWithPerformances(
+        [
+          {
+            venue: {
+              name: 'The Newer Vic',
+              slug: 'the-newer-vic',
+              publiclyListed: true
+            },
+            isInperson: true
+          }
+        ],
+        [
+          {
+            id: 1,
+            name: 'Theatre Improvement Levy',
+            description: 'Makes the STA stonks',
+            percentage: 0.05,
+            fee: null
+          },
+          {
+            id: 2,
+            name: 'Booking Fee',
+            description: 'Oh no Square charges us money',
+            percentage: null,
+            value: 100
+          }
+        ]
+      );
+      console.log(headerContainer.vm.miscCosts);
+
+      expect(headerContainer.vm.miscCostsDisplay).to.equal('5% + £1');
+      expect(headerContainer.text()).to.contain('(exc. fees)');
+    });
+  });
+
   const createWithPerformances = async (
     performances,
+    miscCostsData = [],
     productionOverrides,
     showBuyTicketsButton = true,
     showDetailedInfo = true
@@ -262,6 +362,11 @@ describe('ProductionBanner', function () {
         production,
         showBuyTicketsButton,
         showDetailedInfo
+      },
+      data() {
+        return {
+          miscCosts: miscCostsData
+        };
       }
     });
   };

--- a/tests/unit/components/production/ProductionBanner.spec.js
+++ b/tests/unit/components/production/ProductionBanner.spec.js
@@ -211,7 +211,7 @@ describe('ProductionBanner', function () {
 
   // no buy tickets when not bookable
   it('doesnt show buy tickets button when not bookable', async () => {
-    await createWithPerformances([{}], {
+    await createWithPerformances([{}], [], {
       isBookable: false
     });
     expect(fixTextSpacing(headerContainer.text())).not.to.contain(
@@ -221,12 +221,12 @@ describe('ProductionBanner', function () {
   });
 
   it('doesnt show buy tickets button when told to not be present', async () => {
-    await createWithPerformances([{}], {}, false);
+    await createWithPerformances([{}], [], {}, false);
     expect(headerContainer.find('button').exists()).to.be.false;
   });
 
   it('doesnt show detailed data when told to not show', async () => {
-    await createWithPerformances([{}], {}, false, false);
+    await createWithPerformances([{}], [], {}, false, false);
 
     expect(headerContainer.text()).to.contain('Legally Ginger');
     expect(fixTextSpacing(headerContainer.text())).to.contain('by STA');
@@ -272,76 +272,67 @@ describe('ProductionBanner', function () {
       expect(headerContainer.text()).to.not.contain('(exc. fees)');
     });
 
-    it('calculates correct fee with only a percentage', async () => {
-      await createWithPerformances(
-        [{}],
-        [
-          {
-            id: 1,
-            name: 'Booking Fee',
-            description: 'Supports theatre maintainance and website',
-            percentage: 0.05
-          }
-        ]
-      );
+    const feeTestCases = [
+      {
+        a: [0.05, null],
+        b: [null, null],
+        expected: '5%',
+        testMessage: 'percentage only'
+      },
+      {
+        a: [null, 100],
+        b: [null, null],
+        expected: '£1',
+        testMessage: 'fixed fee only'
+      },
+      {
+        a: [0.05, null],
+        b: [null, 100],
+        expected: '5% + £1',
+        testMessage: 'percentage and fixed fee, handling £s'
+      },
+      {
+        a: [0.1, null],
+        b: [null, 25],
+        expected: '10% + 25p',
+        testMessage: 'percentage and fixed fee, handling pence'
+      },
+      {
+        a: [null, 50],
+        b: [0.05, null],
+        expected: '5% + 50p',
+        testMessage: 'percentage and fixed fee, while order agnostic'
+      }
+    ];
 
-      expect(headerContainer.vm.miscCostsDisplay).to.equal('5%');
-      expect(headerContainer.text()).to.contain('(exc. fees)');
-    });
-
-    it('calculates correct fee with only a fixed fee', async () => {
-      await createWithPerformances(
-        [{}],
-        [
-          {
-            id: 1,
-            name: 'Booking Fee',
-            description: 'Supports theatre maintainance and website',
-            value: 100
-          }
-        ]
-      );
-      console.log(headerContainer.vm.miscCosts);
-      console.log(headerContainer.html());
-
-      expect(headerContainer.vm.miscCostsDisplay).to.equal('£1');
-      expect(headerContainer.text()).to.contain('(exc. fees)');
-    });
-
-    it('calculates correct fee with', async () => {
-      await createWithPerformances(
-        [
-          {
-            venue: {
-              name: 'The Newer Vic',
-              slug: 'the-newer-vic',
-              publiclyListed: true
+    it.each(feeTestCases)(
+      'calculates correct fee with $testMessage',
+      async ({ a, b, expected }) => {
+        await createWithPerformances(
+          [{}],
+          [
+            {
+              id: 1,
+              name: 'Theatre Improvement Levy',
+              description: 'Makes the STA stonks',
+              percentage: a[0],
+              value: a[1]
             },
-            isInperson: true
-          }
-        ],
-        [
-          {
-            id: 1,
-            name: 'Theatre Improvement Levy',
-            description: 'Makes the STA stonks',
-            percentage: 0.05,
-            fee: null
-          },
-          {
-            id: 2,
-            name: 'Booking Fee',
-            description: 'Oh no Square charges us money',
-            percentage: null,
-            value: 100
-          }
-        ]
-      );
-      console.log(headerContainer.vm.miscCosts);
+            {
+              id: 2,
+              name: 'Booking Fee',
+              description: 'Oh no Square charges us money',
+              percentage: b[0],
+              value: b[1]
+            }
+          ]
+        );
+        console.log(headerContainer.vm.miscCosts);
 
-      expect(headerContainer.vm.miscCostsDisplay).to.equal('5% + £1');
-      expect(headerContainer.text()).to.contain('(exc. fees)');
-    });
+        expect(headerContainer.vm.miscCostsDisplay).to.equal(expected);
+        expect(headerContainer.text()).to.contain('(exc. fees)');
+      }
+    );
   });
 
   const createWithPerformances = async (

--- a/tests/unit/components/production/ProductionBanner.spec.js
+++ b/tests/unit/components/production/ProductionBanner.spec.js
@@ -327,7 +327,6 @@ describe('ProductionBanner', function () {
             }
           ]
         );
-        console.log(headerContainer.vm.miscCosts);
 
         expect(headerContainer.vm.miscCostsDisplay).to.equal(expected);
         expect(headerContainer.text()).to.contain('(exc. fees)');

--- a/tests/unit/pages/Home.spec.js
+++ b/tests/unit/pages/Home.spec.js
@@ -117,12 +117,6 @@ describe('Home', function () {
       homepageComponent = await mountComponent();
       await homepageComponent.vm.$nextTick();
 
-      console.log(homepageComponent.vm.userBookingsResult.me?.bookings?.edges);
-      console.log(
-        homepageComponent.vm.userBookingsResult.me?.bookings?.edges[0].node
-          .performance.start
-      );
-
       expect(homepageComponent.findComponent(BookingHomepageOverview).exists())
         .to.be.true;
     });

--- a/tests/unit/support/fixtures/MiscCost.js
+++ b/tests/unit/support/fixtures/MiscCost.js
@@ -4,7 +4,7 @@ export default (overrides = {}) => {
       id: 1,
       name: 'Booking Fee',
       description: 'Supports theatre maintainance and website',
-      percentage: 0.05
+      value: 5
     },
     overrides
   );

--- a/tests/unit/support/fixtures/MiscCost.js
+++ b/tests/unit/support/fixtures/MiscCost.js
@@ -4,8 +4,7 @@ export default (overrides = {}) => {
       id: 1,
       name: 'Booking Fee',
       description: 'Supports theatre maintainance and website',
-      percentage: 0.05,
-      value: 5
+      percentage: 0.05
     },
     overrides
   );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
       dts: false,
       vueTemplate: true
     }), // Auto imports vue composable functions (ref, reactive, etc)
-    Components({ dirs: ['components'], dts: false }) // Replicates Nuxt's auto component importing,
+    Components({ dirs: 'components', dts: false }) // Replicates Nuxt's auto component importing,
   ],
   test: {
     globals: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
       dts: false,
       vueTemplate: true
     }), // Auto imports vue composable functions (ref, reactive, etc)
-    Components({ dirs: 'components', dts: false }) // Replicates Nuxt's auto component importing,
+    Components({ dirs: ['components'], dts: false }) // Replicates Nuxt's auto component importing,
   ],
   test: {
     globals: true,


### PR DESCRIPTION
At present, our fees have a hard-coded description to give them some context to a customer. This PR changes that so fees are queried from the API, meaning if we change our fees (or add/remove some) we do not have to update the hard coded string.

Also, this PR fixes a couple of bugs whereby making changes to a production did not properly reload the page data. This manifested most visibly in a production's admin page not reloading after a production team submits it for a review, meaning the press it a second time and get an authorisation error even though it has worked the first time.

Requires [API PR 851](https://github.com/BristolSTA/uobtheatre-api/pull/851)