### PR TITLE
Fix ticket scanner stuck on loading screen

### DIFF
--- a/components/ui/Input/UiInputTicketScanner.client.vue
+++ b/components/ui/Input/UiInputTicketScanner.client.vue
@@ -2,8 +2,8 @@
   <qrcode-stream
     :camera="!on || cameraReset ? 'off' : 'auto'"
     :track="onTrackEvent"
-    @init="onInit"
-    @decode="onDecode"
+    @camera-on="cameraOn"
+    @detect="onDetect"
   >
     <slot />
   </qrcode-stream>
@@ -56,7 +56,7 @@ function onTrackEvent(detectedCodes: any, ctx: any) {
   }
 }
 
-async function onInit(promise: Promise<any>) {
+async function cameraOn(promise: Promise<any>) {
   try {
     await promise;
     emit('ready');
@@ -90,7 +90,7 @@ async function onInit(promise: Promise<any>) {
     emit('unable', errorMessage);
   }
 }
-function onDecode(string: string) {
+function onDetect(string: string) {
   new Audio('/audio/beep_single.mp3').play();
 
   try {


### PR DESCRIPTION
## Description

This fixes the fact that the box office ticket scanner, when loaded on mobile, would be stuck on the loading screen indefinitely.

## PR Links

- [Demo code of how the scanner should work](https://gruhn.github.io/vue-qrcode-reader/demos/FullDemo.html)

- Fixes #721 

