### PR TITLE
Fix hardware ticket scanner

### DIFF
--- a/classes/Ticket.ts
+++ b/classes/Ticket.ts
@@ -54,9 +54,8 @@ export default class {
     return ticket;
   }
 
-  static dataFromQRCode(detectedCodes: [string]) {
+  static dataFromQRCode(rawValue: string) {
     try {
-      const rawValue = JSON.parse(JSON.stringify(detectedCodes[0])).rawValue;
       const result = JSON.parse(atob(rawValue));
       return {
         bookingReference: result[0],

--- a/components/ui/Input/UiInputTicketScanner.client.vue
+++ b/components/ui/Input/UiInputTicketScanner.client.vue
@@ -94,7 +94,8 @@ function onDetect(string: [string]) {
   new Audio('/audio/beep_single.mp3').play();
 
   try {
-    const ticketData = Ticket.dataFromQRCode(string);
+    const rawValue = JSON.parse(JSON.stringify(string[0])).rawValue;
+    const ticketData = Ticket.dataFromQRCode(rawValue);
     if (props.pauseOnDecode) {
       cameraReset.value = true;
     }

--- a/composables/useHardwareTicketScanner.ts
+++ b/composables/useHardwareTicketScanner.ts
@@ -12,7 +12,7 @@ export default function useHardwareTicketScanner() {
     if (!value) return (ticketDetails.value = undefined);
 
     try {
-      ticketDetails.value = Ticket.dataFromQRCode([value]);
+      ticketDetails.value = Ticket.dataFromQRCode(value);
     } catch (e) {
       if (e instanceof InvalidTicketQRCodeException) {
         return (isInvalid.value = true);

--- a/pages/box-office/[performanceId]/index.vue
+++ b/pages/box-office/[performanceId]/index.vue
@@ -149,7 +149,8 @@ watch(scannedCode, async (newValue) => {
 
   try {
     // Convert the scanned text into ticket data
-    const ticketDetails = Ticket.dataFromQRCode([newValue]);
+    const rawValue = JSON.parse(JSON.stringify(newValue[0])).rawValue;
+    const ticketDetails = Ticket.dataFromQRCode(rawValue);
 
     // Do the scan action as appropriate
     let state = await handleTicketScan(

--- a/tests/unit/classes/Ticket.spec.js
+++ b/tests/unit/classes/Ticket.spec.js
@@ -103,13 +103,7 @@ describe('Ticket Class', () => {
   });
 
   it('can get data from a QR code', () => {
-    expect(
-      Ticket.dataFromQRCode([
-        {
-          rawValue: 'WyJhYmNkMTIzNCIsMl0='
-        }
-      ])
-    ).to.include({
+    expect(Ticket.dataFromQRCode('WyJhYmNkMTIzNCIsMl0=')).to.include({
       bookingReference: 'abcd1234',
       ticketId: 2
     });


### PR DESCRIPTION
## Description

This moves some of the JSON destructuring that happened in #744 to happen on the `.vue` pages rather than within `dataFromQRCode`, so that it no longer breaks physical QR code scanners, but still works for mobile scanners.

## PR Links

- [This Sentry issue](https://bristol-sta.sentry.io/issues/6078404690)
