### PR TITLE
fix: Fix CI codegen issue on the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   # Note: The schema is dev (rather than develop) because that is the branch name on the API repo
   # If this is a push to main or a pull request targeting main, use the main schema
-  SCHEMA_VERSION: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'pull_request' && github.base_ref == 'main' && 'main' || 'dev' }}"
+  SCHEMA_VERSION: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'main' || github.event_name == 'pull_request' && github.base_ref == 'main' && 'main' || 'dev' }}"
 
 jobs:
   test:


### PR DESCRIPTION
Fix pushes to the `main` branch using `/true/` in their codegen rather than `/main/` (silly me)