### PR TITLE
Fix: correct timezones

### DIFF
--- a/components/performance/editor/PerformanceEditor.vue
+++ b/components/performance/editor/PerformanceEditor.vue
@@ -34,31 +34,19 @@
         <form-label name="doorsOpen" :errors="errors" :required="true">
           Doors Open
           <template #control>
-            <VueDatepicker
-              v-model="performance.doorsOpen"
-              :start-time="{ hours: 0, minutes: 0, seconds: 0 }"
-              format="dd/MM/yyyy HH:mm"
-            />
+            <UiInputDateTime v-model="performance.doorsOpen" />
           </template>
         </form-label>
         <form-label name="start" :errors="errors" :required="true">
           Performance Starts
           <template #control>
-            <VueDatepicker
-              v-model="performance.start"
-              :start-time="{ hours: 0, minutes: 0, seconds: 0 }"
-              format="dd/MM/yyyy HH:mm"
-            />
+            <UiInputDateTime v-model="performance.start" />
           </template>
         </form-label>
         <form-label name="end" :errors="errors" :required="true">
           Performance Ends
           <template #control>
-            <VueDatepicker
-              v-model="performance.end"
-              :start-time="{ hours: 0, minutes: 0, seconds: 0 }"
-              format="dd/MM/yyyy HH:mm"
-            />
+            <UiInputDateTime v-model="performance.end" />
           </template>
         </form-label>
         <form-label name="intervalDurationMins" :errors="errors">
@@ -275,7 +263,6 @@ import { swal } from '@/utils/alerts';
 import { dateFormat } from '@/utils/datetime';
 import Alert from '@/components/ui/Alert.vue';
 import { getSingleDiscounts } from '@/utils/performance';
-import VueDatepicker from '@vuepic/vue-datepicker';
 
 import {
   AdminPerformanceDetailDocument,
@@ -293,7 +280,6 @@ import {
 export default {
   components: {
     FormLabel,
-    VueDatepicker,
     SeatGroup,
     ConcessionType,
     ErrorHelper,

--- a/components/ui/Input/UiInputDateTime.vue
+++ b/components/ui/Input/UiInputDateTime.vue
@@ -1,0 +1,67 @@
+<template>
+  <div>
+    <VueDatepicker
+      v-model="date"
+      :start-time="{ hours: 0, minutes: 0, seconds: 0 }"
+      time-picker-inline
+      arrow-navigation
+      text-input
+      :timezone="{ timezone: 'Europe/London' }"
+      :enable-time-picker="enableTimePicker"
+      :format="format"
+      :minutes-increment="minutesIncrement"
+      :placeholder="placeholder"
+      :required="required"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import VueDatepicker from '@vuepic/vue-datepicker';
+
+export default defineComponent({
+  name: 'UiInputDateTime',
+  components: { VueDatepicker },
+  props: {
+    modelValue: {
+      required: true,
+      type: [String, Date]
+    },
+    enableTimePicker: {
+      type: Boolean,
+      default: true
+    },
+    format: {
+      type: String,
+      default: 'dd/MM/yyyy HH:mm'
+    },
+    minutesIncrement: {
+      type: Number,
+      default: 5
+    },
+    placeholder: {
+      type: String,
+      default: null
+    },
+    required: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const date = ref(props.modelValue);
+
+    watch(date, (newDate) => {
+      try {
+        emit('update:modelValue', newDate);
+      } catch (error) {
+        console.error('Invalid date format:', newDate);
+      }
+    });
+
+    return { date };
+  }
+});
+</script>

--- a/pages/administration/finance-reports.vue
+++ b/pages/administration/finance-reports.vue
@@ -14,26 +14,16 @@
           v-if="currentReportObject && currentReportObject.requires_times"
         >
           <h2 class="text-h2">Set report times</h2>
-          <form-label field-name="startTime">
+          <form-label field-name="startTime" :required="true">
             Start Time
             <template #control>
-              <VueDatepicker
-                v-model="start"
-                format="dd/MM/yyyy HH:mm"
-                :required="true"
-                :start-time="{ hours: 0, minutes: 0, seconds: 0 }"
-              />
+              <UiInputDateTime v-model="start" />
             </template>
           </form-label>
-          <form-label field-name="endTime">
+          <form-label field-name="endTime" :required="true">
             End Time
             <template #control>
-              <VueDatepicker
-                v-model="end"
-                format="dd/MM/yyyy HH:mm"
-                :required="true"
-                :start-time="{ hours: 0, minutes: 0, seconds: 0 }"
-              />
+              <UiInputDateTime v-model="end" />
             </template>
           </form-label>
         </template>
@@ -62,14 +52,13 @@ import FormLabel from '@/components/ui/FormLabel.vue';
 import { getValidationErrors, performMutation } from '~~/utils/api';
 import LoadingContainer from '@/components/ui/LoadingContainer.vue';
 import { GenerateReportDocument } from '~~/graphql/codegen/operations';
-import VueDatepicker from '@vuepic/vue-datepicker';
 
 definePageMeta({
   middleware: ['authed', 'finance']
 });
 
 export default defineNuxtComponent({
-  components: { AllErrorsDisplay, FormLabel, LoadingContainer, VueDatepicker },
+  components: { AllErrorsDisplay, FormLabel, LoadingContainer },
   data() {
     return {
       errors: null,

--- a/utils/datetime.ts
+++ b/utils/datetime.ts
@@ -1,5 +1,7 @@
 import humanizeDuration from 'humanize-duration';
-import { DateTime } from 'luxon';
+import { DateTime, Settings } from 'luxon';
+
+Settings.defaultZone = 'Europe/London';
 
 /**
  * Calculates the duration, in ms, between two date times


### PR DESCRIPTION
## Description

Change how dates are formatted before being displayed so that all times are displayed in the correct timezone and displays venue time rather than client local time conversion when in different countries or in DST. Also adds UiDateTimeInput to make VueDatePicker use the correct timezone.

- Resolves #725 
- #26 