### PR TITLE
Set the API to auto-seed

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,13 +23,16 @@ services:
       POSTGRES_PASSWORD: postgres
       DJANGO_SETTINGS_MODULE: config.settings.local
       BASE_URL: http://localhost:9000
+      # This allows us to use all the Makefile commands in the API module (e.g. make seed below)
+      DEV_CONTAINER: true
     env_file:
       - ./.env
     depends_on:
       - postgres
     links:
       - postgres
-    command: /bin/sh -c "/start --single-seed-e2e"
+    # Seed the database with example data
+    command: /bin/sh -c "/start && make seed"
 
   postgres:
     image: postgres:16


### PR DESCRIPTION
A very small change, but one which will mean that the web devcontainers will automatically seed with updated api data from the `fixtures.json` files - and as that gets updated over time, it will always keep the web in sync, as it uses the `make seed` command to do so.

