### PR TITLE
fix: mutating props on production editor

### DIFF
--- a/components/production/editor/ProductionEditor.vue
+++ b/components/production/editor/ProductionEditor.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/no-mutating-props -->
 <template>
   <div class="space-y-2">
     <UiCard title="Basic Details">
@@ -6,15 +5,17 @@
         <form-label :errors="errors" name="name" :required="true">
           Name
           <template #control>
-            <UiInputText v-model="production.name" placeholder="e.g. My Show" />
+            <UiInputText
+              v-model="localProduction.name"
+              placeholder="e.g. My Show"
+            />
           </template>
         </form-label>
         <p v-if="computedSlug">
           <template v-if="!changingSlug">
             Your production will be at
             {{
-              useRouter().resolve({ path: `/productions/${computedSlug}` })
-                .fullPath
+              router.resolve({ path: `/productions/${computedSlug}` }).fullPath
             }}
             <UiStaButton
               class="text-sm bg-sta-orange hover:bg-sta-orange-dark transition-colors"
@@ -41,7 +42,7 @@
                 class="bg-sta-green hover:bg-sta-green-dark transition-colors lg:mx-8 mx-4 mt-6"
                 @click="
                   () => {
-                    production.slug = manualSlug;
+                    localProduction.slug = manualSlug;
                     changingSlug = false;
                   }
                 "
@@ -56,13 +57,13 @@
         <form-label :errors="errors" name="subtitle">
           Subtitle
           <template #control>
-            <UiInputText v-model="production.subtitle" />
+            <UiInputText v-model="localProduction.subtitle" />
           </template>
         </form-label>
         <form-label :errors="errors" name="contactEmail" :required="true">
           Contact Email Address
           <template #control>
-            <UiInputText v-model="production.contactEmail" />
+            <UiInputText v-model="localProduction.contactEmail" />
           </template>
           <template #helper>
             This email will be shown to people equiring about accessibility and
@@ -72,13 +73,13 @@
         <form-label :errors="errors" name="description" :required="true">
           Description
           <template #control>
-            <rich-text-input v-model="production.description" />
+            <rich-text-input v-model="localProduction.description" />
           </template>
         </form-label>
         <form-label :errors="errors" name="shortDescription">
           Short Description
           <template #control>
-            <UiInputText v-model="production.shortDescription" />
+            <UiInputText v-model="localProduction.shortDescription" />
           </template>
           <template #helper>
             This will be shown in place of the description on the front page.
@@ -90,7 +91,8 @@
             <div>
               <table class="w-full">
                 <tr
-                  v-for="contentWarning in production.contentWarnings"
+                  v-for="contentWarning in localProduction.contentWarnings ||
+                  []"
                   :key="contentWarning.warning.id"
                 >
                   <th>
@@ -126,7 +128,6 @@
               <UiStaButton
                 class="bg-sta-green"
                 icon="plus-circle"
-                :small="true"
                 @click="onAddWarning"
               >
                 Add
@@ -137,7 +138,7 @@
         <form-label :errors="errors" name="productionAlert">
           Production Alert
           <template #control>
-            <UiInputText v-model="production.productionAlert" />
+            <UiInputText v-model="localProduction.productionAlert" />
           </template>
           <template #helper>
             A Production Alert is displayed alongside content warnings on a
@@ -154,7 +155,7 @@
           >
             Age Rating
             <UiInputText
-              v-model="production.ageRating"
+              v-model="localProduction.ageRating"
               type="number"
               min="4"
               max="18"
@@ -165,7 +166,7 @@
           </form-label>
           <form-label class="grow" :errors="errors" name="facebookEvent">
             Facebook Event Link
-            <UiInputText v-model="production.facebookEvent" />
+            <UiInputText v-model="localProduction.facebookEvent" />
           </form-label>
         </div>
       </div>
@@ -174,7 +175,7 @@
       <UiInputSelect
         placeholder="Select a society"
         class="mb-4"
-        :model-value="production.society?.id || ''"
+        :model-value="localProduction.society?.id || ''"
         :options="
           availableSocieties.map((society) => ({
             value: society.id,
@@ -182,21 +183,24 @@
           }))
         "
         @update:model-value="
-          production.society = availableSocieties.find(
+          localProduction.society = availableSocieties.find(
             (society) => society.id === $event
           )
         "
       />
 
       <div
-        v-if="production.society"
+        v-if="localProduction.society"
         class="flex items-center justify-center p-4 bg-sta-gray-dark rounded-lg space-x-8"
       >
-        <img :src="production.society.logo.url" style="max-width: 100px" />
-        <span class="text-xl font-semibold">{{ production.society.name }}</span>
+        <img :src="localProduction.society.logo.url" style="max-width: 100px" />
+        <span class="text-xl font-semibold">{{
+          localProduction.society.name
+        }}</span>
       </div>
-      <div v-else>
+      <div v-else class="inline-flex items-center">
         <h4 class="font-bold text-lg">No Society Selected</h4>
+        <required-star />
       </div>
       <error-helper :errors="errors" field-name="society" />
     </UiCard>
@@ -207,15 +211,15 @@
             Feature Image
             <template #helper>
               The main image used to promote your production across the site. It
-              should have a ratio of roughly 16:9
+              should have a ratio of 16:9.
             </template>
             <template #control>
               <image-input
-                :model-value="production.featuredImage?.url"
+                :model-value="localProduction.featuredImage?.url"
                 :required-ratio="16 / 9"
                 :min-width="400"
                 :ratio-flexability="0.13"
-                @change="production.featuredImage = { file: $event }"
+                @change="localProduction.featuredImage = { file: $event }"
               />
             </template>
           </form-label>
@@ -227,10 +231,10 @@
             </template>
             <template #control>
               <image-input
-                :model-value="production.posterImage?.url"
+                :model-value="localProduction.posterImage?.url"
                 :required-ratio="1 / Math.sqrt(2)"
                 :min-width="100"
-                @change="production.posterImage = { file: $event }"
+                @change="localProduction.posterImage = { file: $event }"
               />
             </template>
           </form-label>
@@ -239,15 +243,16 @@
           Cover Image
           <template #helper>
             A cover image used on the homepage carousel. Should have a ratio of
-            roughly 3:1, with at least 1200px width dimension. This image should
-            <strong>not</strong> have any text or logos on it.
+            3:1, with at least 1200px width dimension. This image should
+            <strong>not</strong> have any text or logos on it – it will be used
+            as a background with text on top.
           </template>
           <template #control>
             <image-input
-              :model-value="production.coverImage?.url"
+              :model-value="localProduction.coverImage?.url"
               :required-ratio="3"
               :min-width="1200"
-              @change="production.coverImage = { file: $event }"
+              @change="localProduction.coverImage = { file: $event }"
             />
           </template>
         </form-label>
@@ -256,15 +261,18 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { ref, computed, watch } from 'vue';
+import { useRouter } from 'vue-router';
+import { useQuery } from '@vue/apollo-composable';
 import { v4 as uuid } from 'uuid';
 import kebabCase from 'lodash/kebabCase';
+import cloneDeep from 'lodash/cloneDeep';
 import ImageInput from '../../ui/Input/ImageInput.vue';
 import FormLabel from '../../ui/FormLabel.vue';
-
+import RequiredStar from '~/components/ui/Form/RequiredStar.vue';
 import RichTextInput from '@/components/ui/Input/RichTextInput.vue';
 import Errors from '~~/classes/Errors';
-
 import imageUpload from '~~/services/imageUploadService';
 import ErrorHelper from '@/components/ui/ErrorHelper.vue';
 import { swal } from '@/utils/alerts';
@@ -273,158 +281,161 @@ import {
   AdminSocietiesIndexDocument
 } from '@/graphql/codegen/operations';
 
-export default {
-  components: {
-    FormLabel,
-    ImageInput,
-    RichTextInput,
-    ErrorHelper
+const props = defineProps({
+  errors: {
+    type: Errors,
+    default: null
   },
-  props: {
-    errors: {
-      type: Errors,
-      default: null
-    },
-    production: {
-      type: Object,
-      required: true
-    }
-  },
-  data() {
-    return {
-      availableWarnings: [],
-      availableSocieties: [],
+  production: {
+    type: Object,
+    required: true
+  }
+});
 
-      slugManuallyEdited: false,
-      changingSlug: false,
-      manualSlug: null
-    };
-  },
-  apollo: {
-    availableWarnings: {
-      query: WarningsDocument,
-      update: (data) => data.warnings.edges.map((edge) => edge.node)
-    },
-    availableSocieties: {
-      query: AdminSocietiesIndexDocument,
-      update: (data) => data.societies.edges.map((edge) => edge.node)
-    }
-  },
-  computed: {
-    computedSlug() {
-      return this.production.slug || kebabCase(this.production.name);
-    }
-  },
-  methods: {
-    kebabCase,
-    async onAddWarning() {
-      const { value: warningId } = await swal.fire({
-        input: 'select',
-        inputOptions: Object.fromEntries(
-          this.availableWarnings
-            .filter(
-              (warning) =>
-                !this.production.contentWarnings
-                  .map((cw) => cw.warning.id)
-                  .includes(warning.id)
-            )
-            .map((warning) => [warning.id, warning.shortDescription])
-        ),
-        showCancelButton: true,
-        confirmButtonText: 'Add'
-      });
+const emit = defineEmits(['update:production']);
 
-      if (!warningId) {
-        return;
-      }
+const router = useRouter();
 
-      const warning = this.availableWarnings.find(
-        (warning) => warning.id === warningId
+const changingSlug = ref(false);
+const manualSlug = ref(null);
+
+const localProduction = ref(cloneDeep(props.production));
+
+watch(
+  localProduction,
+  (newVal) => {
+    emit('update:production', newVal);
+  },
+  { deep: true }
+);
+
+const { result: warningsResult } = useQuery(WarningsDocument);
+const availableWarnings = computed(
+  () => warningsResult.value?.warnings.edges.map((edge) => edge.node) || []
+);
+
+const { result: societiesResult } = useQuery(AdminSocietiesIndexDocument);
+const availableSocieties = computed(
+  () => societiesResult.value?.societies.edges.map((edge) => edge.node) || []
+);
+
+const computedSlug = computed(
+  () => localProduction.value.slug || kebabCase(localProduction.value.name)
+);
+
+const onAddWarning = async () => {
+  const { value: warningId } = await swal.fire({
+    input: 'select',
+    inputOptions: Object.fromEntries(
+      availableWarnings.value
+        .filter(
+          (warning) =>
+            !(localProduction.value.contentWarnings || [])
+              .map((cw) => cw.warning.id)
+              .includes(warning.id)
+        )
+        .map((warning) => [warning.id, warning.shortDescription])
+    ),
+    showCancelButton: true,
+    confirmButtonText: 'Add'
+  });
+
+  if (!warningId) {
+    return;
+  }
+
+  const warning = availableWarnings.value.find(
+    (warning) => warning.id === warningId
+  );
+
+  const warningDescriptors = [
+    'Contains themes throughout',
+    'Contains references in dialogue',
+    'Contains graphic references in dialogue',
+    'Contains depiction of this trigger'
+  ];
+
+  const { value: descriptorIndex } = await swal.fire({
+    title: `Please choose a description for "<strong>${warning.shortDescription}</strong>"`,
+    text: 'Note that you can provide a custom, more detailed description by clicking the button below',
+    input: 'select',
+    inputOptions: warningDescriptors,
+    showCancelButton: true,
+    cancelButtonText: 'Let me add my own description',
+    inputPlaceholder: 'Select a description',
+    confirmButtonText: 'Finish'
+  });
+
+  updateWarnings(
+    warning,
+    true,
+    descriptorIndex ? warningDescriptors[descriptorIndex] : null
+  );
+};
+
+const updateWarnings = (warning, include, information = null) => {
+  const current = localProduction.value.contentWarnings || [];
+  localProduction.value.contentWarnings = include
+    ? [...current, { information, warning }]
+    : current.filter(
+        (currentWarning) => currentWarning.warning.id !== warning.id
       );
+};
 
-      const warningDescriptors = [
-        'Contains themes throughout',
-        'Contains references in dialogue',
-        'Contains graphic references in dialogue',
-        'Contains depiction of this trigger'
-      ];
+const getInputData = async () => {
+  const images = {
+    coverImage: localProduction.value.coverImage,
+    featuredImage: localProduction.value.featuredImage,
+    posterImage: localProduction.value.posterImage
+  };
 
-      const { value: descriptorIndex } = await swal.fire({
-        title: `Please choose a description for "<strong>${warning.shortDescription}</strong>"`,
-        text: 'Note that you can provide a custom, more detailed description by clicking the button below',
-        input: 'select',
-        inputOptions: warningDescriptors,
-        showCancelButton: true,
-        cancelButtonText: 'Let me add my own description',
-        inputPlaceholder: 'Select a description',
-        confirmButtonText: 'Finish'
-      });
-
-      this.updateWarnings(
-        warning,
-        true,
-        descriptorIndex ? warningDescriptors[descriptorIndex] : null
+  for (const [key, imageNode] of Object.entries(images)) {
+    if (!imageNode) {
+      continue;
+    }
+    if (imageNode.id) {
+      images[key] = imageNode.id;
+    } else if (imageNode.file) {
+      const image = await imageUpload(
+        imageNode.file,
+        key +
+          `_${localProduction.value.id ?? uuid()}.` +
+          imageNode.file.name.split('.').at(-1)
       );
-    },
-    updateWarnings(warning, include, information = null) {
-      // eslint-disable-next-line vue/no-mutating-props
-      this.production.contentWarnings = include
-        ? [...this.production.contentWarnings, { information, warning }]
-        : this.production.contentWarnings.filter(
-            (currentWarning) => currentWarning.warning.id !== warning.id
-          );
-    },
-    async getInputData() {
-      // Upload any new images
-      const images = {
-        coverImage: this.production.coverImage,
-        featuredImage: this.production.featuredImage,
-        posterImage: this.production.posterImage
-      };
-
-      for (const [key, imageNode] of Object.entries(images)) {
-        if (!imageNode) {
-          continue;
-        }
-        if (imageNode.id) {
-          images[key] = imageNode.id;
-        } else if (imageNode.file) {
-          const image = await imageUpload(
-            imageNode.file,
-            key +
-              `_${this.id ?? uuid()}.` +
-              imageNode.file.name.split('.').at(-1)
-          );
-          images[key] = image ? image.global_id : null;
-        } else {
-          images[key] = null;
-        }
-      }
-
-      const returnObject = {
-        id: this.production.id,
-        name: this.production.name,
-        slug: this.production.slug,
-        subtitle: this.production.subtitle,
-        description: this.production.description,
-        ageRating: this.production.ageRating,
-        facebookEvent: this.production.facebookEvent,
-        contactEmail: this.production.contactEmail,
-        productionAlert: this.production.productionAlert,
-        contentWarnings: (this.production.contentWarnings ?? []).map((cw) => ({
-          id: cw.warning.id,
-          information: cw.information
-        })),
-        society: this.production.society?.id,
-        ...images
-      };
-
-      if (!returnObject.id) {
-        delete returnObject.id;
-      }
-
-      return returnObject;
+      images[key] = image ? image.global_id : null;
+    } else {
+      images[key] = null;
     }
   }
+
+  const returnObject = {
+    id: localProduction.value.id,
+    name: localProduction.value.name,
+    slug: localProduction.value.slug,
+    subtitle: localProduction.value.subtitle,
+    description: localProduction.value.description,
+    ageRating: localProduction.value.ageRating
+      ? parseInt(localProduction.value.ageRating, 10)
+      : null,
+    facebookEvent: localProduction.value.facebookEvent,
+    contactEmail: localProduction.value.contactEmail,
+    productionAlert: localProduction.value.productionAlert,
+    contentWarnings: (localProduction.value.contentWarnings ?? []).map(
+      (cw) => ({
+        id: cw.warning.id,
+        information: cw.information
+      })
+    ),
+    society: localProduction.value.society?.id,
+    ...images
+  };
+
+  if (!returnObject.id) {
+    delete returnObject.id;
+  }
+
+  return returnObject;
 };
+
+defineExpose({ getInputData });
 </script>

--- a/components/ui/Form/RequiredStar.vue
+++ b/components/ui/Form/RequiredStar.vue
@@ -1,3 +1,3 @@
 <template>
-  <span class="text-sta-rouge-dark">*</span>
+  <span class="text-sta-rouge text-sm font-bold">* (required)</span>
 </template>

--- a/pages/administration/productions/[productionSlug]/edit.vue
+++ b/pages/administration/productions/[productionSlug]/edit.vue
@@ -60,7 +60,7 @@ export default defineNuxtComponent({
       this.errors = null;
       loadingSwal.fire();
       try {
-        await performMutation(
+        const data = await performMutation(
           this.$apollo,
           {
             mutation: ProductionMutationDocument,
@@ -70,14 +70,7 @@ export default defineNuxtComponent({
           },
           'production'
         );
-        const { data } = await this.$apollo.query({
-          query: AdminProductionEditQuery,
-          variables: {
-            slug: await this.production.slug
-          },
-          fetchPolicy: 'no-cache'
-        });
-        this.production = data.production;
+        this.production = data.production.production;
         useRouter().push(`/administration/productions/${this.production.slug}`);
         successToast.fire({ title: 'Production Updated' });
       } catch (e) {

--- a/pages/administration/productions/[productionSlug]/edit.vue
+++ b/pages/administration/productions/[productionSlug]/edit.vue
@@ -8,7 +8,12 @@
       </UiStaButton>
     </template>
     <UiNonFieldError :errors="errors" />
-    <production-editor ref="editor" :production="production" :errors="errors" />
+    <production-editor
+      ref="editor"
+      :production="production"
+      :errors="errors"
+      @update:production="updateProduction"
+    />
   </AdminPage>
 </template>
 
@@ -56,6 +61,9 @@ export default defineNuxtComponent({
     };
   },
   methods: {
+    updateProduction(updatedProduction) {
+      this.production = updatedProduction;
+    },
     async save() {
       this.errors = null;
       loadingSwal.fire();
@@ -65,7 +73,7 @@ export default defineNuxtComponent({
           {
             mutation: ProductionMutationDocument,
             variables: {
-              input: await this.$refs.editor.getInputData()
+              input: this.production
             }
           },
           'production'

--- a/tests/unit/components/production/ProductionEditor.spec.js
+++ b/tests/unit/components/production/ProductionEditor.spec.js
@@ -1,0 +1,536 @@
+import { mount } from '#testSupport/helpers';
+import { expect, vi, beforeEach } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+
+import MatchMediaMock from 'vitest-matchmedia-mock';
+
+import Production from '#testSupport/fixtures/Production.js';
+import Society from '#testSupport/fixtures/Society.js';
+import ProductionEditor from '@/components/production/editor/ProductionEditor.vue';
+import {
+  GenericApolloResponse,
+  GenericMutationResponse,
+  GenericNodeConnection
+} from '~/tests/unit/support/helpers/api';
+
+vi.mock('@/utils/alerts', () => ({
+  swal: {
+    fire: vi.fn()
+  }
+}));
+
+vi.mock('@/services/imageUploadService', () => ({
+  default: vi.fn().mockResolvedValue({
+    global_id: 'image_123'
+  })
+}));
+
+// Mock vue-router to handle router injection
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual('vue-router');
+  return {
+    ...actual,
+    useRouter: () => ({
+      resolve: (route) => ({ fullPath: `/productions/test-production` }),
+      push: vi.fn(),
+      replace: vi.fn(),
+      back: vi.fn()
+    })
+  };
+});
+
+describe('ProductionEditor', function () {
+  let editorComponent;
+
+  const createWithProduction = async (
+    productionOverride = null,
+    mutationOverride = null
+  ) => {
+    const mockProduction = Production(productionOverride);
+
+    editorComponent = await mount(ProductionEditor, {
+      shallow: false,
+      routeInfo: {
+        params: {
+          productionSlug: mockProduction.slug
+        }
+      },
+      props: {
+        production: mockProduction
+      },
+      apollo: {
+        queryResponses: [
+          GenericApolloResponse('warnings', GenericNodeConnection()),
+          GenericApolloResponse(
+            'societies',
+            GenericNodeConnection([Array(3).fill(Society())])
+          )
+        ],
+        mutationResponses: [
+          GenericApolloResponse(
+            'production',
+            GenericMutationResponse({
+              production: mockProduction,
+              ...mutationOverride
+            })
+          )
+        ]
+      }
+    });
+
+    await flushPromises();
+  };
+
+  beforeEach(() => {
+    new MatchMediaMock();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Basic Details Rendering', () => {
+    it('renders the editor component', async () => {
+      await createWithProduction();
+
+      expect(editorComponent.exists()).to.be.true;
+    });
+
+    it('populates production name field', async () => {
+      await createWithProduction({ name: 'Test Production' });
+
+      expect(editorComponent.vm.localProduction.name).to.equal(
+        'Test Production'
+      );
+    });
+
+    it('displays computed slug from production name', async () => {
+      await createWithProduction({ name: 'My Test Show', slug: '' });
+
+      expect(editorComponent.vm.computedSlug).to.equal('my-test-show');
+    });
+
+    it('preserves contact email', async () => {
+      const email = 'contact@example.com';
+      await createWithProduction({ contactEmail: email });
+
+      expect(editorComponent.vm.localProduction.contactEmail).to.equal(email);
+    });
+
+    it('preserves subtitle', async () => {
+      const subtitle = 'A great subtitle';
+      await createWithProduction({ subtitle });
+
+      expect(editorComponent.vm.localProduction.subtitle).to.equal(subtitle);
+    });
+
+    it('preserves age rating', async () => {
+      await createWithProduction({ ageRating: 16 });
+
+      expect(editorComponent.vm.localProduction.ageRating).to.equal(16);
+    });
+
+    it('preserves facebook event link', async () => {
+      const fbLink = 'https://facebook.com/test';
+      await createWithProduction({ facebookEvent: fbLink });
+
+      expect(editorComponent.vm.localProduction.facebookEvent).to.equal(fbLink);
+    });
+
+    it('preserves production alert', async () => {
+      const alert = 'This is an important alert';
+      await createWithProduction({ productionAlert: alert });
+
+      expect(editorComponent.vm.localProduction.productionAlert).to.equal(
+        alert
+      );
+    });
+  });
+
+  describe('Slug Management', () => {
+    it('shows slug as computed from name by default', async () => {
+      await createWithProduction({ name: 'Legally Ginger', slug: '' });
+
+      expect(editorComponent.vm.computedSlug).to.equal('legally-ginger');
+      expect(editorComponent.vm.changingSlug).to.be.false;
+    });
+
+    it('allows changing slug manually', async () => {
+      await createWithProduction({ name: 'Test Show', slug: 'test-show' });
+
+      const changeButton = editorComponent
+        .findAll('button')
+        .find((btn) => btn.text() === 'Change');
+
+      await changeButton.trigger('click');
+      await flushPromises();
+
+      expect(editorComponent.vm.changingSlug).to.be.true;
+      expect(editorComponent.vm.manualSlug).to.equal('test-show');
+    });
+
+    it('applies kebab-case formatting to manual slug', async () => {
+      await createWithProduction({ slug: 'test-show' });
+
+      const changeButton = editorComponent
+        .findAll('button')
+        .find((btn) => btn.text() === 'Change');
+
+      await changeButton.trigger('click');
+      await editorComponent.vm.$nextTick();
+
+      const editBox = editorComponent.find('input[value="test-show"]');
+      await editBox.setValue('New Slug With Spaces');
+
+      const doneButton = editorComponent
+        .findAll('button')
+        .find((btn) => btn.text() === 'Done');
+
+      await doneButton.trigger('click');
+      await flushPromises();
+
+      expect(editorComponent.vm.manualSlug).to.equal('new-slug-with-spaces');
+      expect(editorComponent.vm.localProduction.slug).to.equal(
+        'new-slug-with-spaces'
+      );
+    });
+
+    it('confirms slug change with Done button', async () => {
+      await createWithProduction({ slug: 'original-slug' });
+
+      editorComponent.vm.changingSlug = true;
+      editorComponent.vm.manualSlug = 'new-slug';
+      await editorComponent.vm.$nextTick();
+
+      const doneButton = editorComponent
+        .findAll('button')
+        .find((btn) => btn.text() === 'Done');
+
+      await doneButton.trigger('click');
+      await flushPromises();
+
+      expect(editorComponent.vm.localProduction.slug).to.equal('new-slug');
+      expect(editorComponent.vm.changingSlug).to.be.false;
+    });
+  });
+
+  describe('Society Management', () => {
+    it('preserves society data', async () => {
+      const society = Society({ id: '1', name: 'Test Society' });
+      await createWithProduction({ society }, []);
+
+      expect(editorComponent.vm.localProduction.society).to.not.be.null;
+      expect(editorComponent.vm.localProduction.society.name).to.equal(
+        'Test Society'
+      );
+    });
+
+    it('handles no society', async () => {
+      const societies = [Society({ id: '1', name: 'Test Society' })];
+      await createWithProduction({ society: null }, []);
+
+      expect(editorComponent.vm.localProduction.society).to.be.null;
+    });
+
+    it('allows updating society selection', async () => {
+      const soc1 = Society({ id: '1', name: 'Society 1' });
+      const soc2 = Society({ id: '2', name: 'Society 2' });
+
+      await createWithProduction({ society: soc1 }, []);
+
+      editorComponent.vm.localProduction.society = soc2;
+      await editorComponent.vm.$nextTick();
+
+      expect(editorComponent.vm.localProduction.society.id).to.equal('2');
+    });
+  });
+
+  describe('Content Warnings', () => {
+    it('initializes with content warnings array', async () => {
+      const warning = { id: '1', shortDescription: 'Strobe Lighting' };
+      const prod = Production({
+        contentWarnings: [{ warning, information: 'Custom info' }]
+      });
+
+      await createWithProduction(prod, [warning]);
+
+      expect(
+        editorComponent.vm.localProduction.contentWarnings
+      ).to.have.lengthOf(1);
+      expect(
+        editorComponent.vm.localProduction.contentWarnings[0].information
+      ).to.equal('Custom info');
+    });
+
+    it('updates warnings when updateWarnings called', async () => {
+      const warning = {
+        id: '1',
+        shortDescription: 'Nudity',
+        longDescription: 'Nudity description'
+      };
+      await createWithProduction({ contentWarnings: [] }, [warning]);
+
+      editorComponent.vm.updateWarnings(warning, true, 'Custom description');
+      await editorComponent.vm.$nextTick();
+
+      const warnings = editorComponent.vm.localProduction.contentWarnings;
+      expect(warnings).to.have.lengthOf(1);
+      expect(warnings[0].warning.id).to.equal('1');
+      expect(warnings[0].information).to.equal('Custom description');
+    });
+
+    it('removes warning when updateWarnings called with false', async () => {
+      const warning = { id: '1', shortDescription: 'Violence' };
+      const prod = Production({
+        contentWarnings: [{ warning, information: 'Some info' }]
+      });
+
+      await createWithProduction(prod, [warning]);
+
+      expect(
+        editorComponent.vm.localProduction.contentWarnings
+      ).to.have.lengthOf(1);
+
+      editorComponent.vm.updateWarnings(warning, false);
+      await editorComponent.vm.$nextTick();
+
+      expect(
+        editorComponent.vm.localProduction.contentWarnings
+      ).to.have.lengthOf(0);
+    });
+
+    it('allows editing warning information', async () => {
+      const warning = { id: '1', shortDescription: 'Strobe' };
+      const prod = Production({
+        contentWarnings: [{ warning, information: 'Initial' }]
+      });
+
+      await createWithProduction(prod, [warning]);
+
+      editorComponent.vm.localProduction.contentWarnings[0].information =
+        'Updated info';
+      await editorComponent.vm.$nextTick();
+
+      expect(
+        editorComponent.vm.localProduction.contentWarnings[0].information
+      ).to.equal('Updated info');
+    });
+  });
+
+  describe('Image Management', () => {
+    it('preserves featured image', async () => {
+      const prod = Production({
+        featuredImage: {
+          id: 'img_feat_1',
+          url: 'http://example.com/featured.jpg'
+        }
+      });
+
+      await createWithProduction(prod);
+
+      expect(editorComponent.vm.localProduction.featuredImage.id).to.equal(
+        'img_feat_1'
+      );
+    });
+
+    it('preserves poster image', async () => {
+      const prod = Production({
+        posterImage: { id: 'img_post_1', url: 'http://example.com/poster.jpg' }
+      });
+
+      await createWithProduction(prod);
+
+      expect(editorComponent.vm.localProduction.posterImage.id).to.equal(
+        'img_post_1'
+      );
+    });
+
+    it('preserves cover image', async () => {
+      const prod = Production({
+        coverImage: { id: 'img_cov_1', url: 'http://example.com/cover.jpg' }
+      });
+
+      await createWithProduction(prod);
+
+      expect(editorComponent.vm.localProduction.coverImage.id).to.equal(
+        'img_cov_1'
+      );
+    });
+  });
+
+  describe('Short Description Field', () => {
+    it('preserves short description', async () => {
+      await createWithProduction({ shortDescription: 'Short desc' });
+
+      expect(editorComponent.vm.localProduction.shortDescription).to.equal(
+        'Short desc'
+      );
+    });
+
+    it('updates short description', async () => {
+      await createWithProduction({ shortDescription: 'Original' });
+
+      editorComponent.vm.localProduction.shortDescription =
+        'Updated Short Desc';
+      await editorComponent.vm.$nextTick();
+
+      expect(editorComponent.vm.localProduction.shortDescription).to.equal(
+        'Updated Short Desc'
+      );
+    });
+  });
+
+  describe('getInputData', () => {
+    it('returns production input data', async () => {
+      const society = Society({ id: '1' });
+      const production = Production({
+        id: 1,
+        name: 'Test Production',
+        slug: 'test-production',
+        subtitle: 'A subtitle',
+        description: 'A description',
+        contactEmail: 'test@example.com',
+        ageRating: 16,
+        facebookEvent: 'https://facebook.com/test',
+        productionAlert: 'Alert text',
+        society
+      });
+
+      await createWithProduction(production, []);
+
+      const inputData = await editorComponent.vm.getInputData();
+
+      expect(inputData.id).to.equal(1);
+      expect(inputData.name).to.equal('Test Production');
+      expect(inputData.slug).to.equal('test-production');
+      expect(inputData.subtitle).to.equal('A subtitle');
+      expect(inputData.description).to.equal('A description');
+      expect(inputData.contactEmail).to.equal('test@example.com');
+      expect(inputData.ageRating).to.equal(16);
+      expect(inputData.facebookEvent).to.equal('https://facebook.com/test');
+      expect(inputData.productionAlert).to.equal('Alert text');
+      expect(inputData.society).to.equal('1');
+    });
+
+    it('excludes id when creating new production', async () => {
+      const production = Production(
+        { name: 'New Production', id: undefined },
+        false
+      );
+
+      await createWithProduction(production);
+
+      const inputData = await editorComponent.vm.getInputData();
+
+      expect(inputData.id).to.be.undefined;
+    });
+
+    it('converts age rating string to integer', async () => {
+      const production = Production({ ageRating: '14' });
+
+      await createWithProduction(production);
+
+      const inputData = await editorComponent.vm.getInputData();
+
+      expect(inputData.ageRating).to.equal(14);
+      expect(typeof inputData.ageRating).to.equal('number');
+    });
+
+    it('handles null age rating', async () => {
+      const production = Production({ ageRating: null });
+
+      await createWithProduction(production);
+
+      const inputData = await editorComponent.vm.getInputData();
+
+      expect(inputData.ageRating).to.be.null;
+    });
+
+    it('includes content warnings in correct format', async () => {
+      const warning = { id: '1', shortDescription: 'Strobe Lighting' };
+      const production = Production({
+        contentWarnings: [
+          { warning, information: 'Custom strobe warning info' }
+        ]
+      });
+
+      await createWithProduction(production, [warning]);
+
+      const inputData = await editorComponent.vm.getInputData();
+
+      expect(inputData.contentWarnings).to.have.lengthOf(1);
+      expect(inputData.contentWarnings[0].id).to.equal('1');
+      expect(inputData.contentWarnings[0].information).to.equal(
+        'Custom strobe warning info'
+      );
+    });
+
+    it('handles production with existing images', async () => {
+      const production = Production({
+        id: 1,
+        featuredImage: {
+          id: 'img_feat_1',
+          url: 'http://example.com/featured.jpg'
+        },
+        posterImage: { id: 'img_post_1', url: 'http://example.com/poster.jpg' },
+        coverImage: { id: 'img_cov_1', url: 'http://example.com/cover.jpg' }
+      });
+
+      await createWithProduction(production);
+
+      const inputData = await editorComponent.vm.getInputData();
+
+      expect(inputData.featuredImage).to.equal('img_feat_1');
+      expect(inputData.posterImage).to.equal('img_post_1');
+      expect(inputData.coverImage).to.equal('img_cov_1');
+    });
+
+    it('handles production without images', async () => {
+      const production = Production({
+        id: 1,
+        featuredImage: null,
+        posterImage: null,
+        coverImage: null
+      });
+
+      await createWithProduction(production);
+
+      const inputData = await editorComponent.vm.getInputData();
+
+      expect(inputData.featuredImage).to.be.null;
+      expect(inputData.posterImage).to.be.null;
+      expect(inputData.coverImage).to.be.null;
+    });
+  });
+
+  describe('Emission of Updates', () => {
+    it('emits update:production when local production changes', async () => {
+      await createWithProduction({ name: 'Original Name' });
+
+      editorComponent.vm.localProduction.name = 'Updated Name';
+      await editorComponent.vm.$nextTick();
+      await flushPromises();
+
+      const emitted = editorComponent.emitted('update:production');
+      expect(emitted).to.be.ok;
+      expect(emitted.length).to.be.greaterThan(0);
+    });
+
+    it('emits production object with all changes', async () => {
+      await createWithProduction({ name: 'Original' });
+
+      editorComponent.vm.localProduction.subtitle = 'New Subtitle';
+      await flushPromises();
+
+      const emitted = editorComponent.emitted('update:production');
+      const lastEmission = emitted[emitted.length - 1][0];
+
+      expect(lastEmission.subtitle).to.equal('New Subtitle');
+    });
+  });
+
+  afterEach(() => {
+    editorComponent = null;
+    vi.clearAllMocks();
+  });
+});

--- a/tests/unit/pages/admin/productions/EditProduction.spec.js
+++ b/tests/unit/pages/admin/productions/EditProduction.spec.js
@@ -1,0 +1,186 @@
+import { expect, vi, afterEach } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+import { mount } from '#testSupport/helpers';
+
+import MatchMediaMock from 'vitest-matchmedia-mock';
+
+import Production from '../../../support/fixtures/Production';
+import Society from '../../../support/fixtures/Society';
+import ProductionEditPage from '@/pages/administration/productions/[productionSlug]/edit.vue';
+import ProductionEditor from '@/components/production/editor/ProductionEditor.vue';
+import {
+  GenericApolloResponse,
+  GenericMutationResponse,
+  GenericNodeConnection
+} from '~/tests/unit/support/helpers/api';
+
+import { successToast, loadingSwal } from '@/utils/alerts';
+import Swal from 'sweetalert2';
+
+vi.mock('@/services/imageUploadService', () => ({
+  default: vi.fn().mockResolvedValue({
+    global_id: 'image_123'
+  })
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    resolve: ({ path }) => ({ fullPath: path })
+  })
+}));
+
+describe('Production Edit Page', () => {
+  let editPageComponent, successToastSpy, loadingSwalSpy, swalCloseSpy;
+
+  const createEditPage = async (
+    productionOverride = null,
+    mutationOverride = null
+  ) => {
+    let mockProduction = Production(productionOverride);
+
+    editPageComponent = await mount(ProductionEditPage, {
+      shallow: false,
+      routeInfo: {
+        params: {
+          productionSlug: mockProduction.slug
+        }
+      },
+      apollo: {
+        queryResponses: [
+          GenericApolloResponse('production', mockProduction),
+          GenericApolloResponse('warnings', GenericNodeConnection()),
+          GenericApolloResponse(
+            'societies',
+            GenericNodeConnection([Array(3).fill(Society())])
+          )
+        ],
+        mutationResponses: [
+          GenericApolloResponse(
+            'production',
+            GenericMutationResponse({
+              production: mockProduction,
+              ...mutationOverride
+            })
+          )
+        ]
+      }
+    });
+
+    await flushPromises();
+  };
+
+  const swalSpy = () => {
+    loadingSwalSpy = vi.spyOn(loadingSwal, 'fire');
+    successToastSpy = vi.spyOn(successToast, 'fire');
+    swalCloseSpy = vi.spyOn(Swal, 'close');
+  };
+
+  beforeEach(() => {
+    new MatchMediaMock();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the page', async () => {
+    await createEditPage();
+
+    expect(editPageComponent.exists()).to.be.true;
+  });
+
+  it('displays the production name in the title', async () => {
+    const production = Production({ name: 'My Test Show' });
+    await createEditPage(production);
+
+    expect(editPageComponent.text()).to.contain('Edit My Test Show');
+  });
+
+  it('includes the ProductionEditor component', async () => {
+    await createEditPage();
+
+    const editor = editPageComponent.findComponent(ProductionEditor);
+    expect(editor.exists()).to.be.true;
+  });
+
+  it('passes production to the editor', async () => {
+    const production = Production({
+      id: 1,
+      name: 'Test Show',
+      slug: 'test-show'
+    });
+
+    await createEditPage(production);
+
+    const editor = editPageComponent.findComponent(ProductionEditor);
+    expect(editor.props('production').name).to.equal('Test Show');
+    expect(editor.props('production').slug).to.equal('test-show');
+  });
+
+  describe('Toolbar Buttons', () => {
+    it('has a Save Changes button', async () => {
+      await createEditPage();
+
+      const buttons = editPageComponent.findAll('button');
+      const saveButton = buttons.find((btn) =>
+        btn.text().includes('Save Changes')
+      );
+
+      expect(saveButton).to.exist;
+    });
+
+    it('saves changes when Save Changes button is clicked', async () => {
+      await createEditPage(null, {
+        production: Production({ name: 'Updated Show Name' })
+      });
+      swalSpy();
+
+      // Make a change to the production data in the editor
+      const editor = editPageComponent.findComponent(ProductionEditor);
+      const inputs = editor.findAll('input');
+      await inputs.at(0).setValue('Updated Show Name');
+
+      // Check the data has been updated in the editor
+      expect(editor.vm.localProduction.name).to.equal('Updated Show Name');
+
+      // Check the data was emitted to the parent page
+      expect(editor.emitted('update:production')).toBeTruthy();
+      expect(editPageComponent.vm.production.name).to.equal(
+        'Updated Show Name'
+      );
+
+      // Save the production
+      const buttons = editPageComponent.findAll('button');
+      const saveButton = buttons.find((btn) =>
+        btn.text().includes('Save Changes')
+      );
+      await saveButton.trigger('click');
+
+      // Wait for the mutation to resolve and the page to react to it
+      await flushPromises();
+
+      // Expect the save stages to have occures
+      expect(loadingSwalSpy).toHaveBeenCalled();
+      expect(useRouter().push).toHaveBeenCalledWith(
+        '/administration/productions/legally-ginger'
+      );
+      expect(successToastSpy).toHaveBeenCalled();
+      expect(swalCloseSpy).not.toHaveBeenCalled();
+
+      // Check the data did actually update in the editor
+      expect(editPageComponent.vm.production.name).to.equal(
+        'Updated Show Name'
+      );
+    });
+
+    it('has a Cancel button', async () => {
+      await createEditPage();
+
+      const buttons = editPageComponent.findAll('button');
+      const cancelButton = buttons.find((btn) => btn.text().includes('Cancel'));
+
+      expect(cancelButton).to.exist;
+    });
+  });
+});

--- a/tests/unit/pages/admin/productions/EditProduction.spec.js
+++ b/tests/unit/pages/admin/productions/EditProduction.spec.js
@@ -37,7 +37,7 @@ describe('Production Edit Page', () => {
     productionOverride = null,
     mutationOverride = null
   ) => {
-    let mockProduction = Production(productionOverride);
+    const mockProduction = Production(productionOverride);
 
     editPageComponent = await mount(ProductionEditPage, {
       shallow: false,

--- a/tests/unit/pages/admin/productions/ProductionPermissions.spec.js
+++ b/tests/unit/pages/admin/productions/ProductionPermissions.spec.js
@@ -6,7 +6,7 @@ import { GenericApolloResponse } from '#testSupport/helpers/api';
 import { flushPromises } from '@vue/test-utils';
 
 import ProductionPermissionPage from '@/pages/administration/productions/[productionSlug]/permissions.vue';
-import ProductionPermissions from '../../support/fixtures/ProductionPermissions';
+import ProductionPermissions from '../../../support/fixtures/ProductionPermissions';
 import PermissionsAssigner from '@/components/admin/permissions/PermissionsAssigner.vue';
 import AdminPage from '@/components/admin/AdminPage.vue';
 import GenericMutationResponse from '#testSupport/fixtures/support/GenericMutationResponse';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
       ],
       exclude: ['**/README.md'],
       thresholds: {
-        lines: 42.94
+        lines: 45.86
       }
     }
   }


### PR DESCRIPTION
- Removes mutating props in the production editor using a `localProduction` copy. 
  - Tried to clean up some of the code by moving to Vue's Composition API -- thoughts?
- Fixes a bug where changing the slug of a production causes the page to load indefinitely after saving because it tried to redirect to the page using the old slug.