### PR TITLE
chore: upgrade CI Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup node env 🏗
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           check-latest: true
 
       - name: Get yarn cache directory path 🛠
@@ -57,7 +57,7 @@ jobs:
       - name: Setup node env 🏗
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           check-latest: true
 
       - name: Get yarn cache directory path 🛠
@@ -98,7 +98,7 @@ jobs:
       - name: Setup node env 🏗
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           check-latest: true
 
       - name: Get yarn cache directory path 🛠


### PR DESCRIPTION
Upgrade Node v20 in CI workflows to v24.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/