### PR TITLE
fix: image upload fails when the name contains more than one full stop

### DIFF
--- a/components/production/editor/ProductionEditor.vue
+++ b/components/production/editor/ProductionEditor.vue
@@ -391,7 +391,7 @@ export default {
         } else if (imageNode.file) {
           const image = await imageUpload(
             imageNode.file,
-            key + `_${this.id ?? uuid()}.` + imageNode.file.name.split('.')[1]
+            key + `_${this.id ?? uuid()}.` + imageNode.file.name.split('.').at(-1)
           );
           images[key] = image ? image.global_id : null;
         } else {

--- a/components/production/editor/ProductionEditor.vue
+++ b/components/production/editor/ProductionEditor.vue
@@ -391,7 +391,9 @@ export default {
         } else if (imageNode.file) {
           const image = await imageUpload(
             imageNode.file,
-            key + `_${this.id ?? uuid()}.` + imageNode.file.name.split('.').at(-1)
+            key +
+              `_${this.id ?? uuid()}.` +
+              imageNode.file.name.split('.').at(-1)
           );
           images[key] = image ? image.global_id : null;
         } else {

--- a/components/production/editor/ProductionEditor.vue
+++ b/components/production/editor/ProductionEditor.vue
@@ -391,7 +391,9 @@ export default {
         } else if (imageNode.file) {
           const image = await imageUpload(
             imageNode.file,
-            key + `_${this.id ?? uuid()}.` + imageNode.file.name.split('.')[1]
+            key +
+              `_${this.id ?? uuid()}.` +
+              imageNode.file.name.split('.').at(-1)
           );
           images[key] = image ? image.global_id : null;
         } else {


### PR DESCRIPTION
Fixes the issue where uploading images appears to not work if the file name contains multiple full stops and creates an array longer than two.